### PR TITLE
Enforce serverless output limit

### DIFF
--- a/serverless/executor/.gitignore
+++ b/serverless/executor/.gitignore
@@ -17,3 +17,6 @@ Cargo.lock
 # Added by cargo
 
 /target
+
+/runtime/*.js
+/runtime/*.capnp

--- a/serverless/executor/src/job_handler.rs
+++ b/serverless/executor/src/job_handler.rs
@@ -232,7 +232,7 @@ async fn execute_job(
             error_code: 5,
             total_time: execution_timer_start.elapsed().as_millis().into(),
             ..Default::default()
-        })
+        });
     }
 
     Some(JobOutput {

--- a/serverless/executor/src/job_handler.rs
+++ b/serverless/executor/src/job_handler.rs
@@ -13,7 +13,7 @@ use scopeguard::defer;
 use tokio::sync::mpsc::Sender;
 use tokio::time::timeout;
 
-use crate::utils::{AppState, JobOutput, JobsTxnMetadata, JobsTxnType};
+use crate::utils::{AppState, JobOutput, JobsTxnMetadata, JobsTxnType, MAX_OUTPUT_BYTES_LENGTH};
 use crate::workerd;
 use crate::workerd::ServerlessError::*;
 
@@ -21,7 +21,9 @@ use crate::workerd::ServerlessError::*;
 1 => Provided txn hash doesn't belong to the expected rpc chain or code contract
 2 => Calldata corresponding to the txn hash is invalid
 3 => Syntax error in the code extracted from the calldata
-4 => User timeout exceeded */
+4 => User timeout exceeded
+5 => Output size exceeds the limit
+*/
 
 // Execute the job request using workerd runtime and 'cgroup' environment
 pub async fn handle_job(
@@ -223,6 +225,15 @@ async fn execute_job(
     let Ok(response) = workerd::get_workerd_response(port, code_inputs).await else {
         return None;
     };
+
+    if response.len() > MAX_OUTPUT_BYTES_LENGTH {
+        return Some(JobOutput{
+            output: Bytes::new(),
+            error_code: 5,
+            total_time: execution_timer_start.elapsed().as_millis().into(),
+            ..Default::default()
+        })
+    }
 
     Some(JobOutput {
         output: response,

--- a/serverless/executor/src/utils.rs
+++ b/serverless/executor/src/utils.rs
@@ -26,6 +26,7 @@ pub const GAS_LIMIT_BUFFER: u64 = 200000; // Fixed buffer to add to the estimate
 pub const TIMEOUT_TXN_RESEND_DEADLINE: u64 = 20; // Deadline (in secs) for resending pending/dropped execution timeout txns
 pub const RESEND_TXN_INTERVAL: u64 = 5; // Interval (in secs) in which to confirm/resend pending/dropped txns
 pub const RESEND_GAS_PRICE_INCREMENT_PERCENT: u64 = 10; // Gas price increment percent while resending pending/dropped txns
+pub const MAX_OUTPUT_BYTES_LENGTH: usize = 20 * 1024; // 20kB, Maximum allowed serverless output size 
 
 pub type HttpSignerProvider = SignerMiddleware<Provider<Http>, LocalWallet>;
 


### PR DESCRIPTION
Executor will return error code 5 upon computing the serverless output that is larger than size limit.