### PR TITLE
[Serverless] Replace HTTP server with HTTP over vsock

### DIFF
--- a/serverless/gateway/Cargo.lock
+++ b/serverless/gateway/Cargo.lock
@@ -3,189 +3,6 @@
 version = 4
 
 [[package]]
-name = "actix-codec"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f7b0a21988c1bf877cf4759ef5ddaac04c1c9fe808c9142ecb78ba97d97a28a"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d48f96fc3003717aeb9856ca3d02a8c7de502667ad76eeacd830b48d2e91fac4"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "ahash",
- "base64 0.22.1",
- "bitflags",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more 0.99.18",
- "encoding_rs",
- "flate2",
- "futures-core",
- "h2",
- "http 0.2.12",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand",
- "sha1",
- "smallvec",
- "tokio",
- "tokio-util",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
-dependencies = [
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13d324164c51f63867b57e73ba5936ea151b8a41a1d23d1031eeb9f70d0236f8"
-dependencies = [
- "bytestring",
- "cfg-if",
- "http 0.2.12",
- "regex",
- "regex-lite",
- "serde",
- "tracing",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca2549781d8dd6d75c40cf6b6051260a2cc2f3c62343d761a969a0640646894"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "socket2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
-dependencies = [
- "futures-core",
- "paste",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88a1dcdff1466e3c2488e1cb5c36a71822750ad43839937f85d2f4d9f8b705d8"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9180d76e5cc7ccbc4d60a506f2c727730b154010262df5b910eb17dbe4b8cb38"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "ahash",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more 0.99.18",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "impl-more",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "regex-lite",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2",
- "time",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f591380e2e68490b5dfaf1dd1aa0ebe78d84ba7067078512b4ea6e4492d622b8"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn 2.0.91",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,21 +37,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -291,7 +93,7 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more",
  "k256",
  "serde",
 ]
@@ -366,7 +168,7 @@ checksum = "4c986539255fb839d1533c128e190e557e52ff652c9ef62939e233a81dd93f7e"
 dependencies = [
  "alloy-primitives",
  "alloy-rlp",
- "derive_more 1.0.0",
+ "derive_more",
  "k256",
  "serde",
 ]
@@ -383,7 +185,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more",
  "once_cell",
  "serde",
  "sha2",
@@ -472,7 +274,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 1.0.0",
+ "derive_more",
  "foldhash",
  "hashbrown 0.15.2",
  "hex-literal",
@@ -545,7 +347,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
 ]
 
@@ -591,7 +393,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -621,7 +423,7 @@ dependencies = [
  "alloy-primitives",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more",
  "serde",
  "strum",
 ]
@@ -639,7 +441,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "derive_more 1.0.0",
+ "derive_more",
  "itertools 0.13.0",
  "serde",
  "serde_json",
@@ -773,7 +575,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
  "wasmtimer",
@@ -789,7 +591,7 @@ dependencies = [
  "alloy-transport",
  "reqwest",
  "serde_json",
- "tower",
+ "tower 0.5.2",
  "tracing",
  "url",
 ]
@@ -1067,6 +869,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "auto-future"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
+
+[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1082,6 +890,80 @@ name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "tokio",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-test"
+version = "13.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deffdcc6ae7bc024b82f4bd3f46b048781a504588e86716a6d5ccc10b2615e99"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "auto-future",
+ "axum",
+ "bytes",
+ "cookie",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "pretty_assertions",
+ "reserve-port",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "smallvec",
+ "tokio",
+ "tower 0.4.13",
+ "url",
+]
 
 [[package]]
 name = "backtrace"
@@ -1145,6 +1027,12 @@ checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
@@ -1186,27 +1074,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "brotli"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,15 +1101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bytestring"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e465647ae23b2823b0753f50decb2d5a86d2bb2cac04788fafd1f80e45378e5f"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "c-kzg"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,8 +1121,6 @@ version = "1.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
 dependencies = [
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -1327,7 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68578f196d2a33ff61b27fae256c3164f65e36382648e30666dde05b8cc9dfdf"
 dependencies = [
  "async-trait",
- "convert_case 0.6.0",
+ "convert_case",
  "json5",
  "nom",
  "pathdiff",
@@ -1380,12 +1236,6 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "convert_case"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
@@ -1395,11 +1245,10 @@ dependencies = [
 
 [[package]]
 name = "cookie"
-version = "0.16.2"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
- "percent-encoding",
  "time",
  "version_check",
 ]
@@ -1427,15 +1276,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -1524,19 +1364,6 @@ dependencies = [
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
-dependencies = [
- "convert_case 0.4.0",
- "proc-macro2",
- "quote",
- "rustc_version 0.4.1",
- "syn 2.0.91",
-]
-
-[[package]]
-name = "derive_more"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
@@ -1555,6 +1382,12 @@ dependencies = [
  "syn 2.0.91",
  "unicode-xid",
 ]
+
+[[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
@@ -1744,16 +1577,6 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -2054,6 +1877,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -2071,8 +1905,18 @@ dependencies = [
  "bytes",
  "futures-util",
  "http 1.2.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
+]
+
+[[package]]
+name = "http-on-vsock-server"
+version = "0.1.0"
+source = "git+https://github.com/marlinprotocol/oyster-monorepo.git?branch=master#501ec78d9068c4ce436476166b74c78aaea1ea2e"
+dependencies = [
+ "clap",
+ "hyper 0.14.32",
+ "tokio-vsock",
 ]
 
 [[package]]
@@ -2095,6 +1939,30 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
@@ -2103,7 +1971,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.2.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -2120,7 +1988,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper",
+ "hyper 1.5.2",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -2138,8 +2006,8 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "http 1.2.0",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.5.2",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2296,12 +2164,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "impl-more"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae21c3177a27788957044151cc2800043d127acaa460a47ebb9b84dfa2c6aa0"
-
-[[package]]
 name = "impl-trait-for-tuples"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2375,15 +2237,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
-name = "jobserver"
-version = "0.1.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2437,12 +2290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,23 +2320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
-name = "local-channel"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6cbc85e69b8df4b8bb8b89ec634e7189099cea8927a276b7384ce5488e53ec8"
-dependencies = [
- "futures-core",
- "futures-sink",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
-
-[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2515,10 +2345,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -2548,7 +2393,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -2556,7 +2400,7 @@ dependencies = [
 [[package]]
 name = "multi-block-txns"
 version = "0.1.0"
-source = "git+https://github.com/marlinprotocol/oyster-monorepo?branch=master#d7831be6a1d64f73f1459c79172f035c6a599996"
+source = "git+https://github.com/marlinprotocol/oyster-monorepo.git?branch=master#d7831be6a1d64f73f1459c79172f035c6a599996"
 dependencies = [
  "alloy",
  "thiserror 1.0.69",
@@ -2580,6 +2424,18 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nix"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2678,7 +2534,7 @@ version = "0.10.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2922,6 +2778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,7 +2846,7 @@ checksum = "b4c2511913b88df1637da85cc8d96ec8e43a3f8bb8ccb71ee1ac240d6f3df58d"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.6.0",
  "lazy_static",
  "num-traits",
  "rand",
@@ -3065,7 +2931,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3092,12 +2958,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-lite"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
-
-[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3114,9 +2974,9 @@ dependencies = [
  "futures-core",
  "futures-util",
  "http 1.2.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.2",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3131,7 +2991,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -3140,6 +3000,16 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "windows-registry",
+]
+
+[[package]]
+name = "reserve-port"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9838134a2bfaa8e1f40738fcc972ac799de6e0e06b5157acb95fc2b05a0ea283"
+dependencies = [
+ "lazy_static",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3184,7 +3054,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
@@ -3273,7 +3143,7 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -3390,7 +3260,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3470,6 +3340,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af99884400da37c88f5e9146b7f1fd0fbcae8f6eec4e9da38b67d05486f814a6"
+dependencies = [
+ "itoa",
+ "serde",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3494,14 +3374,16 @@ dependencies = [
 name = "serverless-gateway"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "alloy",
  "anyhow",
+ "axum",
+ "axum-test",
  "clap",
  "config",
  "env_logger",
  "futures-core",
  "futures-util",
+ "http-on-vsock-server",
  "log",
  "multi-block-txns",
  "once_cell",
@@ -3512,6 +3394,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-vsock",
 ]
 
 [[package]]
@@ -3701,6 +3584,12 @@ dependencies = [
  "quote",
  "syn 2.0.91",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -3942,6 +3831,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-vsock"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52a15c15b1bc91f90902347eff163b5b682643aff0c8e972912cca79bd9208dd"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "tokio",
+ "vsock",
+]
+
+[[package]]
 name = "toml"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3977,6 +3879,22 @@ dependencies = [
 
 [[package]]
 name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -3984,7 +3902,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -4174,6 +4092,16 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
+dependencies = [
+ "libc",
+ "nix",
+]
 
 [[package]]
 name = "wait-timeout"
@@ -4478,6 +4406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
 name = "yoke"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4583,32 +4517,4 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.91",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
-dependencies = [
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.13+zstd.1.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
-dependencies = [
- "cc",
- "pkg-config",
 ]

--- a/serverless/gateway/Cargo.toml
+++ b/serverless/gateway/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-web = "4.9.0"
+axum = "0.6.20"
 alloy = { version = "0.6.4", features = ["full"] }
 anyhow = "1.0.81"
 clap = { version = "4.5.3", features = ["derive"] }
@@ -14,6 +14,7 @@ config = "0.14.0"
 env_logger = "0.11.3"
 futures-core = "0.3.30"
 futures-util = "0.3.31"
+http-on-vsock-server = { git = "https://github.com/marlinprotocol/oyster-monorepo.git", branch = "master" }
 log = "0.4.21"
 multi-block-txns = { git = "https://github.com/marlinprotocol/oyster-monorepo", branch = "master" }
 once_cell = "1.20.2"
@@ -24,3 +25,7 @@ serde_derive = "1.0.193"
 serde_json = "1.0.88"
 thiserror = "1.0.63"
 tokio = { version = "1.36.0", features = ["full"] }
+tokio-vsock = "0.4.0"
+
+[dev-dependencies]
+axum-test = "13.4.1"

--- a/serverless/gateway/Cargo.toml
+++ b/serverless/gateway/Cargo.toml
@@ -29,3 +29,9 @@ tokio-vsock = "0.4.0"
 
 [dev-dependencies]
 axum-test = "13.4.1"
+
+[profile.release]
+strip = true
+lto = true
+panic = "abort"
+codegen-units = 1

--- a/serverless/gateway/src/api_impl.rs
+++ b/serverless/gateway/src/api_impl.rs
@@ -1,5 +1,3 @@
-use actix_web::web::{Data, Json};
-use actix_web::{get, post, HttpResponse, Responder};
 use alloy::dyn_abi::DynSolValue;
 use alloy::hex;
 use alloy::primitives::{keccak256, Address, U256};
@@ -8,6 +6,10 @@ use alloy::signers::k256::elliptic_curve::generic_array::sequence::Lengthen;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::transports::http::reqwest::Url;
 use anyhow::Context;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use axum::response::{IntoResponse, Response};
 use log::info;
 use multi_block_txns::TxnManager;
 use serde_json::json;
@@ -22,29 +24,24 @@ use crate::model::{
     RequestChainData, SignedRegistrationBody, SignedRegistrationResponse,
 };
 
-#[get("/")]
-async fn index() -> impl Responder {
-    info!("Ping successful!");
-    HttpResponse::Ok()
-}
+pub async fn index() {}
 
 // Endpoint exposed to inject immutable gateway config parameters
-#[post("/immutable-config")]
-async fn inject_immutable_config(
+pub async fn inject_immutable_config(
+    app_state: State<AppState>,
     Json(immutable_config): Json<ImmutableConfig>,
-    app_state: Data<AppState>,
-) -> impl Responder {
+) -> Response {
     let owner_address = Address::from_str(&immutable_config.owner_address_hex);
     let Ok(owner_address) = owner_address else {
-        return HttpResponse::BadRequest().body(format!(
-            "Invalid owner address provided: {:?}",
-            owner_address.unwrap_err()
-        ));
+        return (StatusCode::BAD_REQUEST,
+            format!("Invalid owner address provided: {:?}\n", owner_address.unwrap_err())
+        ).into_response();
     };
 
     let mut immutable_params_injected_guard = app_state.immutable_params_injected.lock().unwrap();
     if *immutable_params_injected_guard {
-        return HttpResponse::BadRequest().body("Immutable params already configured!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Immutable params already configured!\n")).into_response();
     }
 
     // Initialize owner address for the enclave
@@ -53,37 +50,38 @@ async fn inject_immutable_config(
 
     info!("Immutable params configured!");
 
-    HttpResponse::Ok().body("Immutable params configured!")
+    return (StatusCode::OK, String::from("Immutable params configured!\n")).into_response();
 }
 
 // Endpoint exposed to inject mutable gateway config parameters
-#[post("/mutable-config")]
-async fn inject_mutable_config(
+pub async fn inject_mutable_config(
+    app_state: State<AppState>,
     Json(mutable_config): Json<MutableConfig>,
-    app_state: Data<AppState>,
-) -> impl Responder {
+) -> Response {
     let mut bytes32_gas_key = [0u8; 32];
     if let Err(err) = hex::decode_to_slice(&mutable_config.gas_key_hex, &mut bytes32_gas_key) {
-        return HttpResponse::BadRequest().body(format!(
-            "Failed to hex decode the gas private key into 32 bytes: {:?}",
-            err
-        ));
+        return (StatusCode::BAD_REQUEST,
+            format!("Failed to hex decode the gas private key into 32 bytes: {:?}\n", err)
+        ).into_response();
     }
 
     let private_key_signer = mutable_config.gas_key_hex.parse::<PrivateKeySigner>();
 
     let Ok(_) = private_key_signer else {
-        return HttpResponse::BadRequest().body(format!(
-            "Failed to parse the gas private key into a private key signer: {:?}",
-            private_key_signer.unwrap_err()
-        ));
+        return (StatusCode::BAD_REQUEST,
+            format!(
+                "Failed to parse the gas private key into a private key signer: {:?}\n",
+                private_key_signer.unwrap_err()
+            )
+        ).into_response();
     };
 
     let contracts_client_guard = app_state.contracts_client.lock().unwrap();
 
     let mut wallet_guard = app_state.wallet.write().unwrap();
     if *wallet_guard == mutable_config.gas_key_hex {
-        return HttpResponse::NotAcceptable().body("The same wallet address already set.");
+        return (StatusCode::NOT_ACCEPTABLE,
+            String::from("The same wallet address already set.\n")).into_response();
     }
 
     *wallet_guard = mutable_config.gas_key_hex.clone();
@@ -95,10 +93,9 @@ async fn inject_mutable_config(
             .common_chain_txn_manager
             .update_private_signer(mutable_config.gas_key_hex.clone());
         if let Err(e) = res {
-            return HttpResponse::InternalServerError().body(format!(
-                "Failed to update the private signer for the common chain txn manager: {}",
-                e
-            ));
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to update the private signer for the common chain txn manager: {}\n", e)
+            ).into_response();
         }
 
         let mut request_chains_data = contracts_client_guard
@@ -112,10 +109,9 @@ async fn inject_mutable_config(
                 .request_chain_txn_manager
                 .update_private_signer(mutable_config.gas_key_hex.clone());
             if let Err(e) = res {
-                return HttpResponse::InternalServerError().body(format!(
-                    "Failed to update the private signer for the request chain txn manager: {}",
-                    e
-                ));
+                return (StatusCode::INTERNAL_SERVER_ERROR,
+                    format!("Failed to update the private signer for the request chain txn manager: {}\n", e)
+                ).into_response();
             }
         }
     }
@@ -126,19 +122,20 @@ async fn inject_mutable_config(
 
     info!("Mutable params configured!");
 
-    HttpResponse::Ok().body("Mutable params configured!")
+    return (StatusCode::OK, String::from("Mutable params configured!\n")).into_response();
 }
 
 // Endpoint exposed to retrieve the metadata required to register the enclave on the common chain and request chains
-#[get("/signed-registration-message")]
-async fn export_signed_registration_message(
+pub async fn export_signed_registration_message(
+    app_state: State<AppState>,
     Json(signed_registration_body): Json<SignedRegistrationBody>,
-    app_state: Data<AppState>,
-) -> impl Responder {
+) -> Response {
     // if gateway is already registered, return error
     {
         if app_state.registered.load(Ordering::SeqCst) {
-            return HttpResponse::BadRequest().body("Enclave has already been registered.");
+            return (StatusCode::BAD_REQUEST,
+                String::from("Enclave has already been registered.\n")
+            ).into_response();
         }
     }
 
@@ -151,33 +148,43 @@ async fn export_signed_registration_message(
 
     // there should be atleast one request chain id
     if chain_ids.is_empty() {
-        return HttpResponse::BadRequest().body("Atleast one request chain id is required!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Atleast one request chain id is required!\n")
+        ).into_response();
     }
 
     {
         // verify that the app state request chain ids are same as the signed registration body chain ids
         let request_chain_ids_guard = app_state.request_chain_ids.lock().unwrap();
         if !request_chain_ids_guard.is_empty() && *request_chain_ids_guard != chain_ids {
-            return HttpResponse::BadRequest().json(json!({
+            return (StatusCode::BAD_REQUEST,
+                json!({
                     "message": "Request chain ids mismatch!",
                     "chain_ids": *request_chain_ids_guard,
-            }));
+                }).to_string()
+            ).into_response();
         }
     }
 
     // if immutable or mutable params are not configured, return error
     if !*app_state.immutable_params_injected.lock().unwrap() {
-        return HttpResponse::BadRequest().body("Immutable params not configured yet!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Immutable params not configured yet!\n")
+        ).into_response();
     }
 
     // if mutable params are not configured, return error
     if !app_state.mutable_params_injected.load(Ordering::SeqCst) {
-        return HttpResponse::BadRequest().body("Mutable params not configured yet!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Mutable params not configured yet!\n")
+        ).into_response();
     }
 
     // if wallet is not configured, return error
     if app_state.wallet.read().unwrap().is_empty() {
-        return HttpResponse::BadRequest().body("Mutable param wallet not configured yet!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Mutable param wallet not configured yet!\n")
+        ).into_response();
     };
 
     // generate common chain signature
@@ -229,10 +236,12 @@ async fn export_signed_registration_message(
         .enclave_signer_key
         .sign_prehash_recoverable(&digest.to_vec());
     let Ok((rs, v)) = sig else {
-        return HttpResponse::InternalServerError().body(format!(
-            "Failed to sign the registration message using enclave key: {:?}",
-            sig.unwrap_err()
-        ));
+        return  (StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "Failed to sign the registration message using enclave key: {:?}\n",
+                sig.unwrap_err()
+            )
+        ).into_response();
     };
     let common_chain_signature = hex::encode(rs.to_bytes().append(27 + v.to_byte()).to_vec());
 
@@ -271,10 +280,12 @@ async fn export_signed_registration_message(
         .enclave_signer_key
         .sign_prehash_recoverable(&digest.to_vec());
     let Ok((rs, v)) = sig else {
-        return HttpResponse::InternalServerError().body(format!(
-            "Failed to sign the registration message using enclave key: {:?}",
-            sig.unwrap_err()
-        ));
+        return (StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "Failed to sign the registration message using enclave key: {:?}\n",
+                sig.unwrap_err()
+            )
+        ).into_response();
     };
 
     let request_chain_signature = hex::encode(rs.to_bytes().append(27 + v.to_byte()).to_vec());
@@ -283,9 +294,11 @@ async fn export_signed_registration_message(
         ProviderBuilder::new().on_http(Url::parse(&app_state.common_chain_http_url).unwrap());
 
     let Ok(common_chain_block_number) = common_chain_http_provider.get_block_number().await else {
-        return HttpResponse::InternalServerError().body(
-            format!("Failed to fetch the latest block number of the common chain for initiating event listening!")
-        );
+        return (StatusCode::INTERNAL_SERVER_ERROR,
+            format!(
+                "Failed to fetch the latest block number of the common chain for initiating event listening!\n"
+            )
+        ).into_response();
     };
 
     let mut request_chains_data: HashMap<u64, RequestChainData> = HashMap::new();
@@ -307,10 +320,12 @@ async fn export_signed_registration_message(
         {
             Ok(info) => info,
             Err(e) => {
-                return HttpResponse::InternalServerError().body(format!(
-                    "Failed to fetch the request chain data for chain id {}: {}",
-                    chain_id, e
-                ));
+                return (StatusCode::INTERNAL_SERVER_ERROR,
+                    format!(
+                        "Failed to fetch the request chain data for chain id {}: {}\n",
+                        chain_id, e
+                    )
+                ).into_response();
             }
         };
 
@@ -319,12 +334,12 @@ async fn export_signed_registration_message(
             .await;
 
         let Ok(request_chain_http_provider) = request_chain_http_provider else {
-            return HttpResponse::InternalServerError().body(format!(
-                "Failed to connect to the request chain {} http rpc server {}: {}",
-                chain_id,
-                request_chain_info.httpRpcUrl,
-                request_chain_http_provider.unwrap_err()
-            ));
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to connect to the request chain {} http rpc server {}: {}\n",
+                    chain_id, request_chain_info.httpRpcUrl, request_chain_http_provider.unwrap_err()
+                )
+            ).into_response();
         };
 
         let block_number = request_chain_http_provider
@@ -335,7 +350,7 @@ async fn export_signed_registration_message(
                 chain_id
             ))
             .unwrap();
-
+        
         drop(request_chain_http_provider);
 
         let request_chain_txn_manager = TxnManager::new(
@@ -349,10 +364,11 @@ async fn export_signed_registration_message(
         );
 
         let Ok(request_chain_txn_manager) = request_chain_txn_manager else {
-            return HttpResponse::InternalServerError().body(format!(
-                "Failed to create txn manager for request chain {}",
-                chain_id
-            ));
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to create txn manager for request chain {}\n", chain_id
+                )
+            ).into_response();
         };
 
         request_chains_data.insert(
@@ -376,10 +392,12 @@ async fn export_signed_registration_message(
         *request_chain_ids_guard = chain_ids.clone();
     } else {
         if *request_chain_ids_guard != chain_ids {
-            return HttpResponse::BadRequest().json(json!({
-                "message": "Request chain ids mismatch!",
-                "chain_ids": *request_chain_ids_guard,
-            }));
+            return (StatusCode::BAD_REQUEST,
+                json!({
+                    "message": "Request chain ids mismatch!",
+                    "chain_ids": *request_chain_ids_guard,
+                }).to_string()
+            ).into_response();
         }
     }
 
@@ -404,10 +422,10 @@ async fn export_signed_registration_message(
                     .request_chain_txn_manager
                     .update_private_signer(gas_wallet_hex.clone());
                 if let Err(e) = res {
-                    return HttpResponse::InternalServerError().body(format!(
-                        "Failed to update the private signer for the request chain txn manager: {}",
+                    return (StatusCode::INTERNAL_SERVER_ERROR, String::from(format!(
+                        "Failed to update the private signer for the request chain txn manager: {}\n",
                         e
-                    ));
+                    ))).into_response();
                 }
             }
         }
@@ -423,10 +441,11 @@ async fn export_signed_registration_message(
         );
 
         let Ok(common_chain_txn_manager) = common_chain_txn_manager else {
-            return HttpResponse::InternalServerError().body(format!(
-                "Failed to create txn manager for common chain {}",
-                app_state.common_chain_id
-            ));
+            return (StatusCode::INTERNAL_SERVER_ERROR,
+                format!(
+                    "Failed to create txn manager for common chain {}\n", app_state.common_chain_id
+                )
+            ).into_response();
         };
 
         let contracts_client = Arc::new(ContractsClient {
@@ -472,18 +491,21 @@ async fn export_signed_registration_message(
         request_chain_signature,
     };
 
-    HttpResponse::Ok().json(response)
+    (StatusCode::OK, Json(response)).into_response()
 }
 
 // Endpoint exposed to retrieve gateway enclave details
-#[get("/gateway-details")]
-async fn get_gateway_details(app_state: Data<AppState>) -> impl Responder {
+pub async fn get_gateway_details(app_state: State<AppState>) -> Response {
     if !*app_state.immutable_params_injected.lock().unwrap() {
-        return HttpResponse::BadRequest().body("Immutable params not configured yet!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Immutable params not configured yet!\n")
+        ).into_response();
     }
 
     if !app_state.mutable_params_injected.load(Ordering::SeqCst) {
-        return HttpResponse::BadRequest().body("Mutable params not configured yet!");
+        return (StatusCode::BAD_REQUEST,
+            String::from("Mutable params not configured yet!\n")
+        ).into_response();
     }
 
     let wallet: PrivateKeySigner = app_state
@@ -507,7 +529,7 @@ async fn get_gateway_details(app_state: Data<AppState>) -> impl Responder {
         gas_address: wallet.address(),
     };
 
-    HttpResponse::Ok().json(response)
+    (StatusCode::OK, Json(response)).into_response()
 }
 
 #[cfg(test)]
@@ -517,8 +539,8 @@ mod api_impl_tests {
     use std::collections::BTreeSet;
     use std::str::FromStr;
 
-    use actix_web::{body::MessageBody, http};
     use alloy::signers::k256::ecdsa::{RecoveryId, Signature, VerifyingKey};
+    use axum_test::TestServer;
     use serde_json::json;
 
     use crate::test_util::{
@@ -530,73 +552,50 @@ mod api_impl_tests {
     #[tokio::test]
     async fn index_test() {
         let app_state = generate_app_state().await;
-        let app = actix_web::test::init_service(new_app(app_state.clone())).await;
+        let server = TestServer::new(new_app(app_state.clone())).unwrap();
 
-        let req = actix_web::test::TestRequest::get().uri("/").to_request();
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
+        let resp = server.get("/").await;
+        resp.assert_status_ok();
     }
 
     // Test the various response cases for the 'immutable-config' endpoint
     #[tokio::test]
     async fn inject_immutable_config_test() {
         let app_state = generate_app_state().await;
-        let app = actix_web::test::init_service(new_app(app_state.clone())).await;
+        let server = TestServer::new(new_app(app_state.clone())).unwrap();
 
         // Inject invalid hex address string
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
-                "owner_address_hex": "0x32255"
-            }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Invalid owner address provided: OddLength".as_bytes()
-        );
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({"owner_address_hex": "0x32255"}))
+            .await;
+        
+        resp.assert_status_bad_request();
+        resp.assert_text("Invalid owner address provided: OddLength\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.enclave_owner.lock().unwrap(), Address::ZERO);
 
         // Inject invalid hex character address
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
-                "owner_address_hex": "0xzfffffffffffffffffffffffffffffffffffffff"
-            }))
-            .to_request();
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({"owner_address_hex": "0xzfffffffffffffffffffffffffffffffffffffff"}))
+            .await;
 
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Invalid owner address provided: InvalidHexCharacter { c: 'z', index: 0 }".as_bytes()
-        );
+        resp.assert_status_bad_request();
+        resp.assert_text("Invalid owner address provided: InvalidHexCharacter { c: 'z', index: 0 }\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.enclave_owner.lock().unwrap(), Address::ZERO);
 
         // Inject a valid address
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
-                "owner_address_hex": OWNER_ADDRESS
-            }))
-            .to_request();
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({"owner_address_hex": OWNER_ADDRESS}))
+            .await;
 
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params configured!"
-        );
+        resp.assert_status_ok();
+        resp.assert_text("Immutable params configured!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(
@@ -605,20 +604,13 @@ mod api_impl_tests {
         );
 
         // Inject the valid address again
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
-                "owner_address_hex": OWNER_ADDRESS
-            }))
-            .to_request();
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({"owner_address_hex": OWNER_ADDRESS}))
+            .await;
 
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params already configured!"
-        );
+        resp.assert_status_bad_request();
+        resp.assert_text("Immutable params already configured!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(
@@ -631,81 +623,53 @@ mod api_impl_tests {
     #[tokio::test]
     async fn inject_mutable_config_test() {
         let app_state = generate_app_state().await;
-        let app = actix_web::test::init_service(new_app(app_state.clone())).await;
+        let server = TestServer::new(new_app(app_state.clone())).unwrap();
 
         // Inject invalid hex private key string
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": "0x32255"
-            }))
-            .to_request();
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({"gas_key_hex": "0x32255"}))
+            .await;
 
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Failed to hex decode the gas private key into 32 bytes: OddLength".as_bytes()
-        );
+        resp.assert_status_bad_request();
+        resp.assert_text("Failed to hex decode the gas private key into 32 bytes: OddLength\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), String::new());
 
         // Inject invalid private(signing) key
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": "ffffffffffffffffffffffffffffffffffffffffff"
-            }))
-            .to_request();
+        let resp = server
+            .post("/mutable-config")
+            .json(
+                &json!({
+                    "gas_key_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                })
+            ).await;
 
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Failed to hex decode the gas private key into 32 bytes: InvalidStringLength"
-                .as_bytes()
-        );
+        resp.assert_status_bad_request();
+        resp.assert_text("Failed to hex decode the gas private key into 32 bytes: InvalidStringLength\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), String::new());
 
         // Inject invalid gas private key hex string (not ecdsa valid key)
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-            }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Failed to parse the gas private key into a private key signer: EcdsaError(signature::Error { source: None })"
-        );
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({"gas_key_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"}))
+            .await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Failed to parse the gas private key into a private key signer: EcdsaError(signature::Error { source: None })\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), String::new());
 
         // Inject a valid private key for gas wallet
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": GAS_WALLET_KEY
-            }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params configured!"
-        );
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({"gas_key_hex": GAS_WALLET_KEY}))
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Mutable params configured!\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), GAS_WALLET_KEY);
@@ -717,23 +681,21 @@ mod api_impl_tests {
             .unwrap());
 
         // Build contracts client to verify the contracts client public address
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({
                 "owner_address_hex": OWNER_ADDRESS
             }))
-            .to_request();
-        let resp = actix_web::test::call_service(&app, req).await;
-        assert_eq!(resp.status(), http::StatusCode::OK);
+            .await;
+        resp.assert_status_ok();
 
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
-                    "chain_ids": [CHAIN_ID]
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
+                "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-        let resp = actix_web::test::call_service(&app, req).await;
-        assert_eq!(resp.status(), http::StatusCode::OK);
+            .await;
+        resp.assert_status_ok();
         let gas_wallet_address = app_state
             .contracts_client
             .lock()
@@ -750,20 +712,12 @@ mod api_impl_tests {
         );
 
         // Inject the same valid private key for gas wallet again
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": GAS_WALLET_KEY
-            }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::NOT_ACCEPTABLE);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "The same wallet address already set."
-        );
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({"gas_key_hex": GAS_WALLET_KEY}))
+            .await;
+        resp.assert_status(StatusCode::NOT_ACCEPTABLE);
+        resp.assert_text("The same wallet address already set.\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), GAS_WALLET_KEY);
@@ -787,20 +741,12 @@ mod api_impl_tests {
         const GAS_WALLET_PUBLIC_ADDRESS_2: &str = "0x3c44cdddb6a900fa2b585dd299e03d12fa4293bc";
 
         // Inject another valid private key for gas wallet
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
-                "gas_key_hex": GAS_WALLET_KEY_2
-            }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params configured!"
-        );
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({"gas_key_hex": GAS_WALLET_KEY_2}))
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Mutable params configured!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert_eq!(*app_state.wallet.read().unwrap(), GAS_WALLET_KEY_2);
@@ -934,23 +880,17 @@ mod api_impl_tests {
     #[tokio::test]
     async fn export_signed_registration_message_test() {
         let app_state = generate_app_state().await;
-        let app = actix_web::test::init_service(new_app(app_state.clone())).await;
+        let server = TestServer::new(new_app(app_state.clone())).unwrap();
 
         // Get signature without injecting the operator's address or gas key
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params not configured yet!"
-        );
+            .await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Immutable params not configured yet!\n");
         assert!(!*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert!(!app_state.registered.load(Ordering::SeqCst));
@@ -961,20 +901,14 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Inject a valid address into the enclave
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({
                 "owner_address_hex": OWNER_ADDRESS
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params configured!"
-        );
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Immutable params configured!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert!(!app_state.registered.load(Ordering::SeqCst));
@@ -985,20 +919,14 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Get signature without injecting a gas key
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params not configured yet!"
-        );
+            .await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Mutable params not configured yet!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(!app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert!(!app_state.registered.load(Ordering::SeqCst));
@@ -1009,20 +937,14 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Inject a valid private key
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({
                 "gas_key_hex": GAS_WALLET_KEY
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params configured!"
-        );
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Mutable params configured!\n");
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert!(!app_state.registered.load(Ordering::SeqCst));
@@ -1033,18 +955,15 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Get signature with invalid chain id
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": ["invalid u64"]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert!(resp.into_body().try_into_bytes().unwrap().starts_with(
-            "Json deserialize error: invalid type: string \"invalid u64\"".as_bytes()
+            .await;
+        resp.assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(resp.as_bytes().starts_with(
+            "Failed to deserialize the JSON body into the target type".as_bytes()
         ));
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
@@ -1056,19 +975,15 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Get signature with no chain_ids field in json
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({}))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert!(resp
-            .into_body()
-            .try_into_bytes()
-            .unwrap()
-            .starts_with("Json deserialize error: missing field `chain_ids`".as_bytes()));
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({}))
+            .await;
+        resp.assert_status(StatusCode::UNPROCESSABLE_ENTITY);
+        println!("{}", resp.text());
+        assert!(resp.as_bytes().starts_with(
+            "Failed to deserialize the JSON body into the target type: missing field `chain_ids`".as_bytes()
+        ));
         assert!(*app_state.immutable_params_injected.lock().unwrap());
         assert!(app_state.mutable_params_injected.load(Ordering::SeqCst));
         assert!(!app_state.registered.load(Ordering::SeqCst));
@@ -1079,19 +994,16 @@ mod api_impl_tests {
         assert_eq!(*app_state.request_chain_ids.lock().unwrap(), HashSet::new());
 
         // Get signature with valid data points
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
-                    "chain_ids": [CHAIN_ID]
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
+                "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
+            .await;
+        resp.assert_status_ok();
 
         let response: Result<SignedRegistrationResponse, serde_json::Error> =
-            serde_json::from_slice(&resp.into_body().try_into_bytes().unwrap());
+            serde_json::from_slice(&resp.as_bytes());
         assert!(response.is_ok());
 
         let mut chain_id_set: HashSet<u64> = HashSet::new();
@@ -1121,19 +1033,16 @@ mod api_impl_tests {
         ));
 
         // Get signature again with the same chain ids
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
+            .await;
+        resp.assert_status_ok();
 
         let response: Result<SignedRegistrationResponse, serde_json::Error> =
-            serde_json::from_slice(&resp.into_body().try_into_bytes().unwrap());
+            serde_json::from_slice(&resp.as_bytes());
         assert!(response.is_ok());
 
         let mut chain_id_set: HashSet<u64> = HashSet::new();
@@ -1163,121 +1072,78 @@ mod api_impl_tests {
         ));
 
         // Get signature with a different chain id
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": [CHAIN_ID + 1]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
+            .await;
+        resp.assert_status_bad_request();
         assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
+            resp.as_bytes(),
             json!({
-                    "message": "Request chain ids mismatch!",
-                    "chain_ids": [CHAIN_ID],
+                "message": "Request chain ids mismatch!",
+                "chain_ids": [CHAIN_ID],
             })
             .to_string()
-            .try_into_bytes()
-            .unwrap()
+            .as_bytes()
         );
 
         // After on chain registration
         app_state.registered.store(true, Ordering::SeqCst);
 
         // Get signature after registration
-        let req = actix_web::test::TestRequest::get()
-            .uri("/signed-registration-message")
-            .set_json(&json!({
+        let resp = server
+            .post("/signed-registration-message")
+            .json(&json!({
                 "chain_ids": [CHAIN_ID]
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Enclave has already been registered."
-        );
+            .await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Enclave has already been registered.\n");
     }
 
     #[tokio::test]
     async fn get_gateway_details_test() {
         let app_state = generate_app_state().await;
-        let app = actix_web::test::init_service(new_app(app_state.clone())).await;
+        let server = TestServer::new(new_app(app_state.clone())).unwrap();
 
         // Get gateway details without adding wallet and gas key
-        let req = actix_web::test::TestRequest::get()
-            .uri("/gateway-details")
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params not configured yet!"
-        );
+        let resp = server.get("/gateway-details").await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Immutable params not configured yet!\n");
 
         // Inject a valid address into the enclave
-        let req = actix_web::test::TestRequest::post()
-            .uri("/immutable-config")
-            .set_json(&json!({
+        let resp = server
+            .post("/immutable-config")
+            .json(&json!({
                 "owner_address_hex": OWNER_ADDRESS
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Immutable params configured!"
-        );
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Immutable params configured!\n");
 
         // Get gateway details without gas key
-        let req = actix_web::test::TestRequest::get()
-            .uri("/gateway-details")
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::BAD_REQUEST);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params not configured yet!"
-        );
+        let resp = server.get("/gateway-details").await;
+        resp.assert_status_bad_request();
+        resp.assert_text("Mutable params not configured yet!\n");
 
         // Inject a valid private gas key
-        let req = actix_web::test::TestRequest::post()
-            .uri("/mutable-config")
-            .set_json(&json!({
+        let resp = server
+            .post("/mutable-config")
+            .json(&json!({
                 "gas_key_hex": GAS_WALLET_KEY
             }))
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
-        assert_eq!(
-            resp.into_body().try_into_bytes().unwrap(),
-            "Mutable params configured!"
-        );
+            .await;
+        resp.assert_status_ok();
+        resp.assert_text("Mutable params configured!\n");
 
         // Get gateway details
-        let req = actix_web::test::TestRequest::get()
-            .uri("/gateway-details")
-            .to_request();
-
-        let resp = actix_web::test::call_service(&app, req).await;
-
-        assert_eq!(resp.status(), http::StatusCode::OK);
+        let resp = server.get("/gateway-details").await;
+        resp.assert_status_ok();
 
         let response: Result<GatewayDetailsResponse, serde_json::Error> =
-            serde_json::from_slice(&resp.into_body().try_into_bytes().unwrap());
+            serde_json::from_slice(&resp.as_bytes());
         assert!(response.is_ok());
 
         let response = response.unwrap();

--- a/serverless/gateway/src/common_chain_interaction.rs
+++ b/serverless/gateway/src/common_chain_interaction.rs
@@ -1,4 +1,3 @@
-use actix_web::web::Data;
 use alloy::hex::FromHex;
 use alloy::primitives::{keccak256, Address, Bytes, B256, U256};
 use alloy::providers::{Provider, ProviderBuilder, RootProvider, WsConnect};
@@ -6,6 +5,7 @@ use alloy::pubsub::{PubSubFrontend, SubscriptionStream};
 use alloy::rpc::types::{Filter, Log};
 use alloy::sol_types::{SolCall, SolEvent};
 use anyhow::{Context, Result};
+use axum::extract::State;
 use futures_core::stream::Stream;
 use futures_util::stream::StreamExt;
 use log::{error, info};
@@ -47,7 +47,7 @@ use crate::model::{
 };
 
 impl ContractsClient {
-    pub async fn wait_for_registration(self: Arc<Self>, app_state: Data<AppState>) {
+    pub async fn wait_for_registration(self: Arc<Self>, app_state: State<AppState>) {
         info!("Waiting for registration on the Common Chain and all Request Chains...");
         // create a channel to communicate with the main thread
         let (tx, mut rx) = channel::<RegisteredData>(100);

--- a/serverless/gateway/src/main.rs
+++ b/serverless/gateway/src/main.rs
@@ -17,8 +17,8 @@ use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::utils::public_key_to_address;
 use alloy::transports::http::reqwest::Url;
 use anyhow::Context;
-use axum::Router;
 use axum::routing::{get, post};
+use axum::Router;
 use clap::Parser;
 use env_logger::Env;
 use http_on_vsock_server::{VsockAddrParser, VsockServer};
@@ -111,7 +111,10 @@ pub async fn main() -> Result<(), Box<dyn Error>> {
         .route("/immutable-config", post(inject_immutable_config))
         .route("/mutable-config", post(inject_mutable_config))
         .route("/gateway-details", get(get_gateway_details))
-        .route("/signed-registration-message", post(export_signed_registration_message))
+        .route(
+            "/signed-registration-message",
+            post(export_signed_registration_message),
+        )
         .with_state(app_data);
 
     let server = axum::Server::builder(VsockServer {

--- a/serverless/gateway/src/model.rs
+++ b/serverless/gateway/src/model.rs
@@ -6,7 +6,7 @@ use std::collections::{BTreeMap, BTreeSet, BinaryHeap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex, RwLock};
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct AppState {
     pub enclave_signer_key: SigningKey,
     pub enclave_address: Address,
@@ -16,16 +16,16 @@ pub struct AppState {
     pub common_chain_ws_url: String,
     pub gateways_contract_addr: Address,
     pub gateway_jobs_contract_addr: Address,
-    pub request_chain_ids: Mutex<HashSet<u64>>,
+    pub request_chain_ids: Arc<Mutex<HashSet<u64>>>,
     pub registered: Arc<AtomicBool>,
     pub epoch: u64,
     pub time_interval: u64,
     pub offset_for_epoch: u64,
-    pub enclave_owner: Mutex<Address>,
-    pub immutable_params_injected: Mutex<bool>,
+    pub enclave_owner: Arc<Mutex<Address>>,
+    pub immutable_params_injected: Arc<Mutex<bool>>,
     pub mutable_params_injected: Arc<AtomicBool>,
-    pub registration_events_listener_active: Mutex<bool>,
-    pub contracts_client: Mutex<Option<Arc<ContractsClient>>>,
+    pub registration_events_listener_active: Arc<Mutex<bool>>,
+    pub contracts_client: Arc<Mutex<Option<Arc<ContractsClient>>>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/serverless/gateway/src/test_util.rs
+++ b/serverless/gateway/src/test_util.rs
@@ -6,8 +6,8 @@ use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::utils::public_key_to_address;
 use anyhow::Result;
-use axum::Router;
 use axum::routing::{get, post};
+use axum::Router;
 use axum_test::TestServer;
 use once_cell::sync::Lazy;
 use rand::rngs::OsRng;
@@ -70,15 +70,16 @@ pub const CODE_HASH: Lazy<FixedBytes<32>> = Lazy::new(|| {
 });
 
 #[cfg(test)]
-pub fn new_app(
-    app_state: AppState,
-) -> Router<()> {
+pub fn new_app(app_state: AppState) -> Router<()> {
     Router::new()
         .route("/", get(index))
         .route("/immutable-config", post(inject_immutable_config))
         .route("/mutable-config", post(inject_mutable_config))
         .route("/gateway-details", get(get_gateway_details))
-        .route("/signed-registration-message", post(export_signed_registration_message))
+        .route(
+            "/signed-registration-message",
+            post(export_signed_registration_message),
+        )
         .with_state(app_state)
 }
 

--- a/serverless/gateway/src/test_util.rs
+++ b/serverless/gateway/src/test_util.rs
@@ -1,9 +1,3 @@
-use actix_web::web::Data;
-use actix_web::{
-    body::MessageBody,
-    dev::{ServiceFactory, ServiceRequest, ServiceResponse},
-    App, Error,
-};
 use alloy::dyn_abi::DynSolValue;
 use alloy::hex;
 use alloy::primitives::{keccak256, Address, FixedBytes, Log as InnerLog, LogData, B256, U256};
@@ -12,6 +6,9 @@ use alloy::signers::k256::ecdsa::SigningKey;
 use alloy::signers::local::PrivateKeySigner;
 use alloy::signers::utils::public_key_to_address;
 use anyhow::Result;
+use axum::Router;
+use axum::routing::{get, post};
+use axum_test::TestServer;
 use once_cell::sync::Lazy;
 use rand::rngs::OsRng;
 use serde_json::json;
@@ -74,34 +71,26 @@ pub const CODE_HASH: Lazy<FixedBytes<32>> = Lazy::new(|| {
 
 #[cfg(test)]
 pub fn new_app(
-    app_state: Data<AppState>,
-) -> App<
-    impl ServiceFactory<
-        ServiceRequest,
-        Response = ServiceResponse<impl MessageBody + std::fmt::Debug>,
-        Config = (),
-        InitError = (),
-        Error = Error,
-    >,
-> {
-    App::new()
-        .app_data(app_state)
-        .service(index)
-        .service(inject_immutable_config)
-        .service(inject_mutable_config)
-        .service(export_signed_registration_message)
-        .service(get_gateway_details)
+    app_state: AppState,
+) -> Router<()> {
+    Router::new()
+        .route("/", get(index))
+        .route("/immutable-config", post(inject_immutable_config))
+        .route("/mutable-config", post(inject_mutable_config))
+        .route("/gateway-details", get(get_gateway_details))
+        .route("/signed-registration-message", post(export_signed_registration_message))
+        .with_state(app_state)
 }
 
 #[cfg(test)]
-pub async fn generate_app_state() -> Data<AppState> {
+pub async fn generate_app_state() -> AppState {
     // Initialize random 'secp256k1' signing key for the enclave
 
     use std::sync::RwLock;
 
     let signer_key = SigningKey::random(&mut OsRng);
 
-    Data::new(AppState {
+    AppState {
         enclave_signer_key: signer_key.clone(),
         enclave_address: public_key_to_address(&signer_key.verifying_key()),
         wallet: Arc::new(RwLock::new(String::new())),
@@ -110,52 +99,45 @@ pub async fn generate_app_state() -> Data<AppState> {
         common_chain_ws_url: WS_URL.to_owned(),
         gateways_contract_addr: GATEWAYS_CONTRACT_ADDR.parse::<Address>().unwrap(),
         gateway_jobs_contract_addr: GATEWAY_JOBS_CONTRACT_ADDR.parse::<Address>().unwrap(),
-        request_chain_ids: Mutex::new(HashSet::new()),
+        request_chain_ids: Arc::new(Mutex::new(HashSet::new())),
         registered: Arc::new(AtomicBool::new(false)),
-        registration_events_listener_active: Mutex::new(false),
+        registration_events_listener_active: Arc::new(Mutex::new(false)),
         epoch: EPOCH,
         time_interval: TIME_INTERVAL,
         offset_for_epoch: OFFSET_FOR_EPCOH,
-        enclave_owner: Mutex::new(Address::ZERO),
-        immutable_params_injected: Mutex::new(false),
+        enclave_owner: Arc::new(Mutex::new(Address::ZERO)),
+        immutable_params_injected: Arc::new(Mutex::new(false)),
         mutable_params_injected: Arc::new(AtomicBool::new(false)),
-        contracts_client: Mutex::new(None),
-    })
+        contracts_client: Arc::new(Mutex::new(None)),
+    }
 }
 
 #[cfg(test)]
 pub async fn generate_contracts_client() -> Arc<ContractsClient> {
     let app_state = generate_app_state().await;
-    let app = actix_web::test::init_service(new_app(app_state.clone())).await;
 
+    let server = TestServer::new(new_app(app_state.clone())).unwrap();
     // add immutable config
-    let req = actix_web::test::TestRequest::post()
-        .uri("/immutable-config")
-        .set_json(&json!({
+    let _resp = server
+        .post("/immutable-config")
+        .json(&json!({
             "owner_address_hex": OWNER_ADDRESS
         }))
-        .to_request();
-    actix_web::test::call_service(&app, req).await;
-
+        .await;
     // add mutable config
-    let req = actix_web::test::TestRequest::post()
-        .uri("/mutable-config")
-        .set_json(&json!({
+    let _resp = server
+        .post("/mutable-config")
+        .json(&json!({
             "gas_key_hex": GAS_WALLET_KEY
         }))
-        .to_request();
-    actix_web::test::call_service(&app, req).await;
-
+        .await;
     // Get signature with valid data points
-    let req = actix_web::test::TestRequest::get()
-        .uri("/signed-registration-message")
-        .set_json(&json!({
+    let _resp = server
+        .post("/signed-registration-message")
+        .json(&json!({
             "chain_ids": [CHAIN_ID]
         }))
-        .to_request();
-
-    actix_web::test::call_service(&app, req).await;
-
+        .await;
     let contracts_client = app_state.contracts_client.lock().unwrap().clone().unwrap();
 
     contracts_client

--- a/serverless/http-on-vsock-client/Cargo.toml
+++ b/serverless/http-on-vsock-client/Cargo.toml
@@ -3,6 +3,14 @@ name = "http-on-vsock-client"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "gateway-vsock-client"
+path = "src/gw_vsock_client.rs"
+
+[[bin]]
+name = "executor-vsock-client"
+path = "src/exec_vsock_client.rs"
+
 [dependencies]
 clap = { version = "4.4.6", features = ["derive"] }
 hyper = { version = "0.14.27", features = ["full"] }

--- a/serverless/http-on-vsock-client/README.md
+++ b/serverless/http-on-vsock-client/README.md
@@ -42,7 +42,8 @@ Options:
 ```
 
 ```bash
-$ ./gateway-vsock-client --helpUsage: gateway-vsock-client [OPTIONS] --url <URL> --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
+$ ./gateway-vsock-client --help
+Usage: gateway-vsock-client [OPTIONS] --url <URL> --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
 
 Options:
   -u, --url <URL>                      url to query
@@ -60,7 +61,7 @@ $ ./executor-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS>
 ```
 
 ```bash
-$ ./gateway-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY> -c 3 -c 4
+$ ./gateway-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY> -c 31337 -c 421614
 ```
 ## License
 

--- a/serverless/http-on-vsock-client/README.md
+++ b/serverless/http-on-vsock-client/README.md
@@ -30,13 +30,25 @@ Supported outputs:
 ## Usage
 
 ```bash
-$ ./http-on-vsock-client --help
-Usage: http-on-vsock-client --url <URL> --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
+$ ./executor-vsock-client --help
+Usage: executor-vsock-client --url <URL> --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
 
 Options:
   -u, --url <URL>                      url to query
-  -o, --owner-address <OWNER_ADDRESS>  
-  -g, --gas-key <GAS_KEY>              
+  -o, --owner-address <OWNER_ADDRESS>  owner address
+  -g, --gas-key <GAS_KEY>              gas key
+  -h, --help                           Print help
+  -V, --version                        Print version
+```
+
+```bash
+$ ./gateway-vsock-client --helpUsage: gateway-vsock-client [OPTIONS] --url <URL> --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
+
+Options:
+  -u, --url <URL>                      url to query
+  -o, --owner-address <OWNER_ADDRESS>  owner address
+  -g, --gas-key <GAS_KEY>              gas key
+  -c, --chain-ids <CHAIN_IDS>          list of chain ids
   -h, --help                           Print help
   -V, --version                        Print version
 ```
@@ -44,7 +56,11 @@ Options:
 ## Example
 
 ```bash
-$ ./http-on-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
+$ ./executor-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY>
+```
+
+```bash
+$ ./gateway-vsock-client --url vsock://88:6000/ --owner-address <OWNER_ADDRESS> --gas-key <GAS_KEY> -c 3 -c 4
 ```
 ## License
 

--- a/serverless/http-on-vsock-client/src/exec_vsock_client.rs
+++ b/serverless/http-on-vsock-client/src/exec_vsock_client.rs
@@ -1,0 +1,80 @@
+use clap::Parser;
+use http_on_vsock_client::vsock_client::vsock_connector;
+use hyper::{body::Body, Request, Uri};
+use serde_json::json;
+
+#[derive(Parser)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    /// url to query
+    #[clap(short, long, value_parser)]
+    url: String,
+
+    /// owner address
+    #[clap(short, long, value_parser)]
+    owner_address: String,
+
+    /// gas key
+    #[clap(short, long, value_parser)]
+    gas_key: String,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    // WARN: Had to do Box::pin to get it to work, vsock_connector is not Unpin for some reason
+    let connector = tower::service_fn(|dst: Uri| Box::pin(vsock_connector(dst)));
+
+    let client = hyper::Client::builder().build::<_, Body>(connector);
+
+    while let Err(err) = client.get(cli.url.clone().try_into()?).await {
+        if err.is_connect() {
+            println!("{:?}", err);
+            println!("Connection refused, retrying...");
+            // sleep for 1 second
+            tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
+            continue;
+        }
+        return Err(err.into());
+    };
+
+    // prepare the post request
+    let body = json!({
+        "owner_address_hex": cli.owner_address.clone(),
+    }).to_string();
+    let request = Request::post(cli.url.clone()+"immutable-config")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body))?;
+    let mut resp = client.request(request).await?;
+    println!("{:?}", resp);
+    println!("{:?}", String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?);
+
+    // set mutable config
+    let body = json!({
+        "gas_key_hex": cli.gas_key.clone(),
+    }).to_string();
+    let request = Request::post(cli.url.clone()+"mutable-config")
+        .header("Content-Type", "application/json")
+        .body(Body::from(body))?;
+    resp = client.request(request).await?;
+    println!("{:?}", resp);
+    println!("{:?}", String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?);
+
+
+    // Get the config
+    resp = client.get((cli.url.clone() + "executor-details").try_into()?).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let body_str = String::from_utf8(body_bytes.to_vec())?;
+    let json: serde_json::Value = serde_json::from_str(&body_str)?;
+    println!("{:?}", json);
+
+    // Start the executor
+    resp = client.get((cli.url.clone() + "signed-registration-message").try_into()?).await?;
+    let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
+    let body_str = String::from_utf8(body_bytes.to_vec())?;
+    let json: serde_json::Value = serde_json::from_str(&body_str)?;
+    println!("{:?}", json);
+
+    Ok(())
+}


### PR DESCRIPTION
Http over vsock secures the communication between serverless operator and the enclave. Configurations are made securely over this connection. Connections can only originate from the nitro enclave host, thus preventing any other external access.