### PR TITLE
[Serverless] Add api key as mutable config for executor

### DIFF
--- a/serverless/executor/oyster_serverless_executor_config.json
+++ b/serverless/executor/oyster_serverless_executor_config.json
@@ -2,7 +2,7 @@
     "workerd_runtime_path": "./runtime/",
     "common_chain_id": 421614,
     "http_rpc_url": "https://sepolia-rollup.arbitrum.io/rpc",
-    "web_socket_url": "wss://arb-sepolia.g.alchemy.com/v2/U8uYtmU3xK9j7HEZ74riWfj3C4ode7n1",
+    "web_socket_url": "wss://arb-sepolia.g.alchemy.com/v2/",
     "executors_contract_addr": "0xE35E287DBC371561E198bFaCBdbEc9cF78bDe930",
     "jobs_contract_addr": "0xd3b682f6F58323EC77dEaE730733C6A83a1561Fd",
     "code_contract_addr": "0x44fe06d2940b8782a0a9a9ffd09c65852c0156b1",

--- a/serverless/executor/src/event_handler.rs
+++ b/serverless/executor/src/event_handler.rs
@@ -29,17 +29,17 @@ pub async fn events_listener(app_state: State<AppState>, starting_block: U64) {
     }
     loop {
         // web socket connection
-        let web_socket_client =
-            match Provider::<Ws>::connect_with_reconnects(&app_state.ws_rpc_url, 0).await {
-                Ok(client) => client,
-                Err(err) => {
-                    eprintln!(
-                        "Failed to connect to the common chain websocket provider: {:?}",
-                        err
-                    );
-                    continue;
-                }
-            };
+        let ws_rpc_url = app_state.ws_rpc_url.read().unwrap().clone();
+        let web_socket_client = match Provider::<Ws>::connect_with_reconnects(ws_rpc_url, 0).await {
+            Ok(client) => client,
+            Err(err) => {
+                eprintln!(
+                    "Failed to connect to the common chain websocket provider: {:?}",
+                    err
+                );
+                continue;
+            }
+        };
 
         if !app_state.enclave_registered.load(Ordering::SeqCst) {
             // Create filter to listen to the 'ExecutorRegistered' event emitted by the Executors contract

--- a/serverless/executor/src/main.rs
+++ b/serverless/executor/src/main.rs
@@ -70,7 +70,7 @@ async fn main() -> Result<()> {
         .parse::<Uri>()
         .context("Invalid web_socket_url format")?;
     if !config.web_socket_url.ends_with('/') {
-        return Err(anyhow!("web_socket_url should not end with a '/'"));
+        return Err(anyhow!("web_socket_url should end with a '/'"));
     }
 
     let enclave_address = public_key_to_address(&enclave_signer_key.verifying_key());

--- a/serverless/executor/src/main.rs
+++ b/serverless/executor/src/main.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64};
 use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::{anyhow, Context, Result};
+use axum::http::Uri;
 use axum::routing::{get, post};
 use axum::Router;
 use clap::Parser;
@@ -58,6 +59,19 @@ async fn main() -> Result<()> {
             .as_slice(),
     )
     .context("Invalid enclave signer key")?;
+
+    // Validate the format of the http_rpc_url and web_socket_url
+    let _ = config
+        .http_rpc_url
+        .parse::<Uri>()
+        .context("Invalid http_rpc_url format")?;
+    let _ = config
+        .web_socket_url
+        .parse::<Uri>()
+        .context("Invalid web_socket_url format")?;
+    if !config.web_socket_url.ends_with('/') {
+        return Err(anyhow!("web_socket_url should not end with a '/'"));
+    }
 
     let enclave_address = public_key_to_address(&enclave_signer_key.verifying_key());
 

--- a/serverless/executor/src/main.rs
+++ b/serverless/executor/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::Arc;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex, RwLock};
 
 use anyhow::{anyhow, Context, Result};
 use axum::routing::{get, post};
@@ -70,12 +69,12 @@ async fn main() -> Result<()> {
         execution_buffer_time: config.execution_buffer_time,
         common_chain_id: config.common_chain_id,
         http_rpc_url: config.http_rpc_url,
-        ws_rpc_url: config.web_socket_url,
+        ws_rpc_url: Arc::new(RwLock::new(config.web_socket_url)),
         executors_contract_addr: config.executors_contract_addr,
         jobs_contract_addr: config.jobs_contract_addr,
         code_contract_addr: config.code_contract_addr,
         num_selected_executors: config.num_selected_executors,
-        enclave_address: enclave_address,
+        enclave_address,
         enclave_signer: enclave_signer_key,
         immutable_params_injected: Arc::new(Mutex::new(false)),
         mutable_params_injected: Arc::new(Mutex::new(false)),

--- a/serverless/executor/src/node_handler.rs
+++ b/serverless/executor/src/node_handler.rs
@@ -168,8 +168,8 @@ pub async fn inject_mutable_config(
     *app_state.http_rpc_client.lock().unwrap() = Some(http_rpc_client);
     let mut ws_rpc_url = app_state.ws_rpc_url.write().unwrap();
     // strip existing api key from the ws url by removing keys after last '/'
-    let pos = ws_rpc_url.rfind('/').unwrap_or(0);
-    let _ = ws_rpc_url.split_off(pos + 1);
+    let pos = ws_rpc_url.rfind('/').unwrap();
+    ws_rpc_url.truncate(pos + 1);
     ws_rpc_url.push_str(mutable_config.ws_api_key.as_str());
     *mutable_params_injected_guard = true;
 

--- a/serverless/executor/src/utils.rs
+++ b/serverless/executor/src/utils.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 use std::sync::atomic::{AtomicBool, AtomicU64};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
@@ -58,7 +58,7 @@ pub struct AppState {
     pub execution_buffer_time: u64,
     pub common_chain_id: u64,
     pub http_rpc_url: String,
-    pub ws_rpc_url: String,
+    pub ws_rpc_url: Arc<RwLock<String>>,
     pub executors_contract_addr: Address,
     pub jobs_contract_addr: Address,
     pub code_contract_addr: String,
@@ -85,6 +85,7 @@ pub struct ImmutableConfig {
 #[derive(Debug, Serialize, Deserialize)]
 pub struct MutableConfig {
     pub gas_key_hex: String,
+    pub ws_api_key: String,
 }
 
 #[derive(Serialize)]
@@ -93,6 +94,7 @@ pub struct ExecutorConfig {
     pub enclave_public_key: String,
     pub owner_address: H160,
     pub gas_address: H160,
+    pub ws_rpc_url: String,
 }
 
 #[derive(Serialize)]

--- a/serverless/http-on-vsock-client/src/gw_vsock_client.rs
+++ b/serverless/http-on-vsock-client/src/gw_vsock_client.rs
@@ -41,33 +41,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             continue;
         }
         return Err(err.into());
-    };
+    }
 
     // prepare the post request
     let body = json!({
         "owner_address_hex": cli.owner_address.clone(),
-    }).to_string();
-    let request = Request::post(cli.url.clone()+"immutable-config")
+    })
+    .to_string();
+    let request = Request::post(cli.url.clone() + "immutable-config")
         .header("Content-Type", "application/json")
         .body(Body::from(body))?;
     let mut resp = client.request(request).await?;
     println!("{:?}", resp.status());
-    println!("{:?}", String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?);
+    println!(
+        "{:?}",
+        String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?
+    );
 
     // set mutable config
     let body = json!({
         "gas_key_hex": cli.gas_key.clone(),
-    }).to_string();
-    let request = Request::post(cli.url.clone()+"mutable-config")
+    })
+    .to_string();
+    let request = Request::post(cli.url.clone() + "mutable-config")
         .header("Content-Type", "application/json")
         .body(Body::from(body))?;
     resp = client.request(request).await?;
     println!("{:?}", resp.status());
-    println!("{:?}", String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?);
-
+    println!(
+        "{:?}",
+        String::from_utf8(hyper::body::to_bytes(resp.into_body()).await?.to_vec())?
+    );
 
     // Get the config
-    resp = client.get((cli.url.clone() + "gateway-details").try_into()?).await?;
+    resp = client
+        .get((cli.url.clone() + "gateway-details").try_into()?)
+        .await?;
     let body_bytes = hyper::body::to_bytes(resp.into_body()).await?;
     let body_str = String::from_utf8(body_bytes.to_vec())?;
     let json: serde_json::Value = serde_json::from_str(&body_str)?;
@@ -76,7 +85,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Start the executor
     let body = json!({
         "chain_ids": cli.chain_ids.clone(),
-    }).to_string();
+    })
+    .to_string();
     println!("{:?}", body);
     let request = Request::post(cli.url.clone() + "signed-registration-message")
         .header("Content-Type", "application/json")

--- a/serverless/http-on-vsock-client/src/vsock_client.rs
+++ b/serverless/http-on-vsock-client/src/vsock_client.rs
@@ -1,7 +1,10 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::{client::connect::{Connected, Connection}, Uri};
+use hyper::{
+    client::connect::{Connected, Connection},
+    Uri,
+};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub struct VsockStream(tokio_vsock::VsockStream);

--- a/serverless/http-on-vsock-client/src/vsock_client.rs
+++ b/serverless/http-on-vsock-client/src/vsock_client.rs
@@ -1,10 +1,8 @@
 use std::pin::Pin;
 use std::task::{Context, Poll};
 
-use hyper::{
-    client::connect::{Connected, Connection},
-    Uri,
-};
+use hyper::client::connect::{Connected, Connection};
+use hyper::Uri;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
 pub struct VsockStream(tokio_vsock::VsockStream);


### PR DESCRIPTION
For websocket connections, alchemy url will be hardcoded in the executor encalve PCRs and operator has to configure the api key upon startup. Also, operator can update the existing api key too.  For changes to take in effect, operator has to revoke older key from alchemy dashboard.
