### PR TITLE
fix: ipset not found

### DIFF
--- a/networking/iperf3-enclave/tuna/default.nix
+++ b/networking/iperf3-enclave/tuna/default.nix
@@ -64,7 +64,7 @@ in {
     env = "";
     copyToRoot = pkgs.buildEnv {
       name = "image-root";
-      paths = [app pkgs.busybox pkgs.nettools pkgs.iproute2 pkgs.iptables-legacy pkgs.iperf3];
+      paths = [app pkgs.busybox pkgs.nettools pkgs.iproute2 pkgs.iptables-legacy pkgs.iperf3 pkgs.ipset];
       pathsToLink = ["/bin" "/app" "/etc"];
     };
   };


### PR DESCRIPTION
While running https://artifacts.marlin.org/oyster/eifs/iperf3-tuna_v1.0.0_linux_arm64.eif image, execution of `/app/setup.sh` was erroring out due to `ipset not found`