### PR TITLE
Simpler scallop + user data in decoded attestation

### DIFF
--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.12.0"
+version = "0.13.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/examples/axum.rs
+++ b/sdks/rs/examples/axum.rs
@@ -22,29 +22,28 @@ use tower::Service;
 
 pub use oyster::scallop::*;
 
+type Pcrs = [[u8; 48]; 3];
+
 #[derive(Default)]
 struct AuthStore {
     store: HashMap<Key, Pcrs>,
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&self, key: &Key) -> bool {
-        self.store.contains_key(key)
-    }
-
-    fn get(&self, key: &Key) -> Option<&Pcrs> {
-        self.store.get(key)
-    }
-
-    fn set(&mut self, key: Key, pcrs: Pcrs) {
-        self.store.insert(key, pcrs);
-    }
-
-    fn verify(&mut self, attestation: &[u8], _key: &Key) -> Option<Pcrs> {
-        if attestation == b"good auth" {
-            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
+    fn contains(&mut self, key: &Key) -> ContainsResponse {
+        if self.store.contains_key(key) {
+            ContainsResponse::Approved
         } else {
-            None
+            ContainsResponse::NotFound
+        }
+    }
+
+    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+        if attestation == b"good auth" {
+            self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
+            true
+        } else {
+            false
         }
     }
 }

--- a/sdks/rs/examples/hyper.rs
+++ b/sdks/rs/examples/hyper.rs
@@ -19,29 +19,28 @@ use tokio::time::sleep;
 
 pub use oyster::scallop::*;
 
+type Pcrs = [[u8; 48]; 3];
+
 #[derive(Default)]
 struct AuthStore {
     store: HashMap<Key, Pcrs>,
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&self, key: &Key) -> bool {
-        self.store.contains_key(key)
-    }
-
-    fn get(&self, key: &Key) -> Option<&Pcrs> {
-        self.store.get(key)
-    }
-
-    fn set(&mut self, key: Key, pcrs: Pcrs) {
-        self.store.insert(key, pcrs);
-    }
-
-    fn verify(&mut self, attestation: &[u8], _key: &Key) -> Option<Pcrs> {
-        if attestation == b"good auth" {
-            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
+    fn contains(&mut self, key: &Key) -> ContainsResponse {
+        if self.store.contains_key(key) {
+            ContainsResponse::Approved
         } else {
-            None
+            ContainsResponse::NotFound
+        }
+    }
+
+    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+        if attestation == b"good auth" {
+            self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
+            true
+        } else {
+            false
         }
     }
 }

--- a/sdks/rs/examples/scallop.rs
+++ b/sdks/rs/examples/scallop.rs
@@ -11,29 +11,28 @@ use tokio::time::sleep;
 
 pub use oyster::scallop::*;
 
+type Pcrs = [[u8; 48]; 3];
+
 #[derive(Default)]
 struct AuthStore {
     store: HashMap<Key, Pcrs>,
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&self, key: &Key) -> bool {
-        self.store.contains_key(key)
-    }
-
-    fn get(&self, key: &Key) -> Option<&Pcrs> {
-        self.store.get(key)
-    }
-
-    fn set(&mut self, key: Key, pcrs: Pcrs) {
-        self.store.insert(key, pcrs);
-    }
-
-    fn verify(&mut self, attestation: &[u8], _key: &Key) -> Option<Pcrs> {
-        if attestation == b"good auth" {
-            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
+    fn contains(&mut self, key: &Key) -> ContainsResponse {
+        if self.store.contains_key(key) {
+            ContainsResponse::Approved
         } else {
-            None
+            ContainsResponse::NotFound
+        }
+    }
+
+    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+        if attestation == b"good auth" {
+            self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
+            true
+        } else {
+            false
         }
     }
 }

--- a/sdks/rs/src/attestation.rs
+++ b/sdks/rs/src/attestation.rs
@@ -102,6 +102,9 @@ pub fn verify(
     // return the enclave key
     result.public_key = parse_enclave_key(&mut attestation_doc)?;
 
+    // return the user data
+    result.user_data = parse_user_data(&mut attestation_doc)?;
+
     Ok(result)
 }
 
@@ -301,6 +304,24 @@ fn parse_enclave_key(
     })?;
 
     Ok(public_key)
+}
+
+fn parse_user_data(
+    attestation_doc: &mut BTreeMap<Value, Value>,
+) -> Result<Vec<u8>, AttestationError> {
+    let user_data = attestation_doc
+        .remove(&"user_data".to_owned().into())
+        .ok_or(AttestationError::ParseFailed(
+            "user data not found in attestation doc".to_owned(),
+        ))?;
+    let user_data = (match user_data {
+        Value::Bytes(b) => Ok(b),
+        _ => Err(AttestationError::ParseFailed(
+            "user data decode failure".to_owned(),
+        )),
+    })?;
+
+    Ok(user_data)
 }
 
 pub async fn get(endpoint: Uri) -> Result<Vec<u8>, AttestationError> {

--- a/sdks/rs/src/attestation.rs
+++ b/sdks/rs/src/attestation.rs
@@ -21,6 +21,7 @@ pub struct AttestationDecoded {
     pub pcrs: [[u8; 48]; 3],
     pub root_public_key: Vec<u8>,
     pub public_key: Vec<u8>,
+    pub user_data: Vec<u8>,
 }
 
 #[derive(thiserror::Error, Debug)]
@@ -53,6 +54,7 @@ pub fn verify(
         timestamp: 0,
         root_public_key: Vec::new(),
         public_key: Vec::new(),
+        user_data: Vec::new(),
     };
 
     // parse attestation doc

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -180,9 +180,9 @@ pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
     fn contains(&self, key: &Key) -> bool;
-    fn get(&self, key: &Key) -> Option<&Pcrs>;
-    fn set(&mut self, key: Key, pcrs: Pcrs);
-    fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<Pcrs>;
+    fn get(&self, key: &Key) -> Option<&(Pcrs, UserData)>;
+    fn set(&mut self, key: Key, pcrs: Pcrs, user_data: UserData);
+    fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<(Pcrs, UserData)>;
 }
 
 impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -175,11 +175,21 @@ enum ReadMode {
 }
 
 pub type Key = [u8; 32];
+pub enum ContainsResponse {
+    // the key was found and is approved
+    Approved,
+    // the key was not found
+    NotFound,
+    // the key is rejected
+    Rejected,
+}
 
 pub trait ScallopAuthStore {
     // intended as a caching mechanism so attestations do not have to be
-    // requested every time
-    fn contains(&mut self, key: &Key) -> bool;
+    // requested every time, always returning NotFound is valid
+    fn contains(&mut self, _key: &Key) -> ContainsResponse {
+        ContainsResponse::NotFound
+    }
     fn verify(&mut self, attestation: &[u8], key: &Key) -> bool;
 }
 

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -177,6 +177,8 @@ enum ReadMode {
 pub type Key = [u8; 32];
 
 pub trait ScallopAuthStore {
+    // intended as a caching mechanism so attestations do not have to be
+    // requested every time
     fn contains(&mut self, key: &Key) -> bool;
     fn verify(&mut self, attestation: &[u8], key: &Key) -> bool;
 }

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -191,7 +191,7 @@ pub trait ScallopAuthStore {
     fn contains(&mut self, _key: &Key) -> ContainsResponse {
         ContainsResponse::NotFound
     }
-    fn verify(&mut self, attestation: &[u8], key: &Key) -> bool;
+    fn verify(&mut self, attestation: &[u8], key: Key) -> bool;
 }
 
 impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
@@ -199,7 +199,7 @@ impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
         (**self).contains(key)
     }
 
-    fn verify(&mut self, attestation: &[u8], key: &Key) -> bool {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
         (**self).verify(attestation, key)
     }
 }
@@ -210,7 +210,7 @@ impl ScallopAuthStore for () {
         unimplemented!()
     }
 
-    fn verify(&mut self, _attestation: &[u8], _key: &Key) -> bool {
+    fn verify(&mut self, _attestation: &[u8], _key: Key) -> bool {
         unimplemented!()
     }
 }
@@ -515,7 +515,7 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         if !auth_store
             .as_mut()
             .unwrap()
-            .verify(&noise_buf[2..len], &remote_static)
+            .verify(&noise_buf[2..len], remote_static)
         {
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
@@ -652,7 +652,7 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         if !auth_store
             .as_mut()
             .unwrap()
-            .verify(&noise_buf[3..len], &remote_static)
+            .verify(&noise_buf[3..len], remote_static)
         {
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -175,8 +175,6 @@ enum ReadMode {
 }
 
 pub type Key = [u8; 32];
-pub type Pcrs = [[u8; 48]; 3];
-pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
     fn contains(&mut self, key: &Key) -> bool;

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -180,8 +180,6 @@ pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
     fn contains(&self, key: &Key) -> bool;
-    fn get(&self, key: &Key) -> Option<&(Pcrs, UserData)>;
-    fn set(&mut self, key: Key, pcrs: Pcrs, user_data: UserData);
     fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<(Pcrs, UserData)>;
 }
 

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -188,14 +188,6 @@ impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
         (**self).contains(key)
     }
 
-    fn get(&self, key: &Key) -> Option<&(Pcrs, UserData)> {
-        (**self).get(key)
-    }
-
-    fn set(&mut self, key: Key, pcrs: Pcrs, user_data: UserData) {
-        (**self).set(key, pcrs, user_data)
-    }
-
     fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<(Pcrs, UserData)> {
         (**self).verify(attestation, key)
     }
@@ -204,14 +196,6 @@ impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
 // to let callers pass in None with empty type
 impl ScallopAuthStore for () {
     fn contains(&self, _key: &Key) -> bool {
-        unimplemented!()
-    }
-
-    fn get(&self, _key: &Key) -> Option<&(Pcrs, UserData)> {
-        unimplemented!()
-    }
-
-    fn set(&mut self, _key: Key, _pcrs: Pcrs, _user_data: UserData) {
         unimplemented!()
     }
 
@@ -518,8 +502,6 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         else {
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
-
-        auth_store.unwrap().set(remote_static, pcrs, user_data);
     }
 
     //---- <- SERVERFIN end ----//
@@ -651,8 +633,6 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         else {
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
-
-        auth_store.unwrap().set(remote_static, pcrs, user_data);
     }
 
     // auth request should be 0 or 1

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -179,7 +179,7 @@ pub type Pcrs = [[u8; 48]; 3];
 pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
-    fn contains(&self, key: &Key) -> bool;
+    fn contains(&mut self, key: &Key) -> bool;
     fn verify(&mut self, attestation: &[u8], key: &Key) -> bool;
 }
 

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -176,6 +176,7 @@ enum ReadMode {
 
 pub type Key = [u8; 32];
 pub type Pcrs = [[u8; 48]; 3];
+pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
     fn contains(&self, key: &Key) -> bool;

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -190,15 +190,15 @@ impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
         (**self).contains(key)
     }
 
-    fn get(&self, key: &Key) -> Option<&Pcrs> {
+    fn get(&self, key: &Key) -> Option<&(Pcrs, UserData)> {
         (**self).get(key)
     }
 
-    fn set(&mut self, key: Key, pcrs: Pcrs) {
-        (**self).set(key, pcrs)
+    fn set(&mut self, key: Key, pcrs: Pcrs, user_data: UserData) {
+        (**self).set(key, pcrs, user_data)
     }
 
-    fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<Pcrs> {
+    fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<(Pcrs, UserData)> {
         (**self).verify(attestation, key)
     }
 }
@@ -209,15 +209,15 @@ impl ScallopAuthStore for () {
         unimplemented!()
     }
 
-    fn get(&self, _key: &Key) -> Option<&Pcrs> {
+    fn get(&self, _key: &Key) -> Option<&(Pcrs, UserData)> {
         unimplemented!()
     }
 
-    fn set(&mut self, _key: Key, _pcrs: Pcrs) {
+    fn set(&mut self, _key: Key, _pcrs: Pcrs, _user_data: UserData) {
         unimplemented!()
     }
 
-    fn verify(&mut self, _attestation: &[u8], _key: &Key) -> Option<Pcrs> {
+    fn verify(&mut self, _attestation: &[u8], _key: &Key) -> Option<(Pcrs, UserData)> {
         unimplemented!()
     }
 }
@@ -513,7 +513,7 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         }
 
         // verify
-        let Some(pcrs) = auth_store
+        let Some((pcrs, user_data)) = auth_store
             .as_mut()
             .unwrap()
             .verify(&noise_buf[2..len], &remote_static)
@@ -521,7 +521,7 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
 
-        auth_store.unwrap().set(remote_static, pcrs);
+        auth_store.unwrap().set(remote_static, pcrs, user_data);
     }
 
     //---- <- SERVERFIN end ----//
@@ -646,7 +646,7 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     // verify auth if we asked for it
     if should_ask_auth {
         // verify
-        let Some(pcrs) = auth_store
+        let Some((pcrs, user_data)) = auth_store
             .as_mut()
             .unwrap()
             .verify(&noise_buf[3..len], &remote_static)
@@ -654,7 +654,7 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
 
-        auth_store.unwrap().set(remote_static, pcrs);
+        auth_store.unwrap().set(remote_static, pcrs, user_data);
     }
 
     // auth request should be 0 or 1

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -180,7 +180,7 @@ pub type UserData = Box<[u8]>;
 
 pub trait ScallopAuthStore {
     fn contains(&self, key: &Key) -> bool;
-    fn verify(&mut self, attestation: &[u8], key: &Key) -> Option<(Pcrs, UserData)>;
+    fn verify(&mut self, attestation: &[u8], key: &Key) -> bool;
 }
 
 impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {


### PR DESCRIPTION
Removed stuff like Pcrs from the scallop interface, the implementation can just pick how and what it persists. E.g. implementations might want to use `user_data`, or non-enclave attestations for that matter.