### PR TITLE
Major scallop changes and misc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /result
+.aider*

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -281,12 +281,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -768,16 +762,6 @@ name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
-
-[[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "byteorder",
- "num-traits",
-]
 
 [[package]]
 name = "heck"
@@ -1352,7 +1336,6 @@ dependencies = [
  "snow",
  "thiserror 2.0.3",
  "tokio",
- "tower",
 ]
 
 [[package]]
@@ -1900,13 +1883,9 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
- "indexmap 2.6.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -193,7 +193,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http",
@@ -202,7 +202,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit",
+ "matchit 0.7.3",
  "memchr",
  "mime",
  "percent-encoding",
@@ -212,7 +212,41 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
+dependencies = [
+ "axum-core 0.5.0",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.8.4",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -235,7 +269,27 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1362f362fd16024ae199c1970ce98f9661bf5ef94b9808fee734bc3698b733"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1220,6 +1274,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,7 +1407,8 @@ name = "oyster-sdk"
 version = "0.14.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
- "axum",
+ "axum 0.7.9",
+ "axum 0.8.1",
  "chrono",
  "clap",
  "hex",
@@ -1755,12 +1816,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -1912,9 +1967,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -1922,7 +1977,7 @@ dependencies = [
  "indexmap 2.6.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -72,9 +72,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android-tzdata"
@@ -132,11 +132,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
@@ -252,9 +253,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "blake2"
@@ -282,15 +283,15 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "13208fcbb66eaeffe09b99fffbe1af420f00a7b35aa99ad683dfc1aa76145229"
 dependencies = [
  "shlex",
 ]
@@ -327,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -353,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.21"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
+checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -363,9 +364,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.21"
+version = "4.5.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
+checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
 dependencies = [
  "anstream",
  "anstyle",
@@ -375,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -387,9 +388,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afb84c814227b90d6895e01398aee0d8033c00e7466aca416fb6a8e0eb19d8a7"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "colorchoice"
@@ -414,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
  "libc",
 ]
@@ -432,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -574,12 +575,12 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -728,7 +729,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -759,21 +760,15 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.1"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hex"
@@ -789,9 +784,9 @@ checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "http"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
 dependencies = [
  "bytes",
  "fnv",
@@ -835,9 +830,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97818827ef4f364230e16705d4706e2897df2bb60617d6ca15d598025a3c481f"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1054,12 +1049,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
+checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.1",
+ "hashbrown 0.15.2",
  "serde",
 ]
 
@@ -1080,24 +1075,25 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "540654e97a3f4470a492cd30ff187bc95d89557a903a2bbf112e2fae98104ef2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "js-sys"
-version = "0.3.72"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a88f1bda2bd75b0452a14784937d796722fdebfe50df998aeb3f0b7603019a9"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.164"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "433bfe06b8c75da9b2e3fbea6e5329ff87748f0b144ef75306e674c3f6f7c13f"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libflate"
@@ -1153,15 +1149,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "litemap"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
@@ -1181,9 +1177,9 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 
 [[package]]
 name = "matchit"
@@ -1205,26 +1201,25 @@ checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minisign-verify"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a05b5d0594e0cb1ad8cee3373018d2b84e25905dc75b2468114cc9a8e86cfc20"
+checksum = "6367d84fb54d4242af283086402907277715b8fe46976963af5ebf173f8efba3"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "hermit-abi",
  "libc",
  "wasi",
  "windows-sys 0.52.0",
@@ -1247,9 +1242,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -1334,7 +1329,7 @@ dependencies = [
  "serde_cbor",
  "serde_json",
  "snow",
- "thiserror 2.0.3",
+ "thiserror",
  "tokio",
 ]
 
@@ -1369,9 +1364,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1416,18 +1411,18 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.90"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e1ced3fe749df87a909c23e9607ab9a09c8f0bedb7e03b8146f4c08c298673"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -1443,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
  "bitflags",
 ]
@@ -1473,22 +1468,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.41"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7f649912bc1495e167a6edee79151c84b1bad49748cb4f1f1167f459f6224f6"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
  "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
@@ -1504,15 +1499,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
+checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
@@ -1538,9 +1533,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1549,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -1594,15 +1589,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -1612,9 +1607,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -1687,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1715,9 +1710,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.88"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8e9a4e1639f47f655bf8e5198232f05615d5fb7e864ef5c4f5abdaf8ad3b8f4"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1754,38 +1749,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
 dependencies = [
- "thiserror-impl 1.0.69",
-]
-
-[[package]]
-name = "thiserror"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
-dependencies = [
- "thiserror-impl 2.0.3",
+ "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.69"
+version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1794,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.36"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
@@ -1815,9 +1790,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.18"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -1835,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.41.1"
+version = "1.43.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
+checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1853,9 +1828,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1864,9 +1839,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e7c3654c13bcd040d4a03abee2c75b1d14a37b423cf5a813ceae1cc903ec6a"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1905,9 +1880,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.40"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -1916,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
@@ -1953,9 +1928,9 @@ dependencies = [
 
 [[package]]
 name = "ureq"
-version = "2.10.1"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
 dependencies = [
  "base64",
  "log",
@@ -1965,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.3"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -2021,24 +1996,24 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "128d1e363af62632b8eb57219c8fd7877144af57558fb2ef0368d0087bddeb2e"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb6dd4d3ca0ddffd1dd1c9c04f94b868c37ff5fac97c30b97cff2d74fce3a358"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2047,9 +2022,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e79384be7f8f5a9dd5d7167216f022090cf1f9ec128e6e6a482a2cb5c5422c56"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2057,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2070,9 +2045,12 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.95"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "windows-core"
@@ -2179,9 +2157,9 @@ checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "xattr"
-version = "1.3.1"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da84f1a25939b27f6820d92aed108f83ff920fdf11a7b19366c27c4cda81d4f"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
 dependencies = [
  "libc",
  "linux-raw-sys",
@@ -2190,9 +2168,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2202,9 +2180,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2234,18 +2212,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2283,18 +2261,18 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.2.0"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5e4288ea4057ae23afc69a4472434a87a2495cafce6632fd1c4ec9f5cf3494"
+checksum = "ae9c1ea7b3a5e1f4b922ff856a129881167511563dc219869afe3787fc0c1a45"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
  "displaydoc",
  "flate2",
- "indexmap 2.6.0",
+ "indexmap 2.7.0",
  "memchr",
- "thiserror 1.0.69",
+ "thiserror",
  "zopfli",
 ]
 

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.1"
+version = "0.14.2"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -150,17 +150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -188,45 +177,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d6fd624c75e18b3b4c6b9caf42b1afe24437daaee904069137d8bab077be8b8"
 dependencies = [
- "axum-core 0.5.0",
+ "axum-core",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -236,7 +191,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "percent-encoding",
@@ -249,27 +204,6 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1269,12 +1203,6 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
-
-[[package]]
-name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -1407,8 +1335,7 @@ name = "oyster-sdk"
 version = "0.14.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
- "axum 0.7.9",
- "axum 0.8.1",
+ "axum",
  "chrono",
  "clap",
  "hex",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1344,7 +1344,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.3"
+version = "0.14.4"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1316,7 +1316,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.0"
+version = "0.14.1"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.lock
+++ b/sdks/rs/Cargo.lock
@@ -1311,7 +1311,7 @@ dependencies = [
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.2"
+version = "0.14.3"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.14.3"
+version = "0.14.4"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.14.2"
+version = "0.14.3"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -22,12 +22,17 @@ serde_json = "1.0"
 snow = "0.9.6"
 thiserror = "2.0.3"
 tokio = { version = "1", features = ["full"] }
+# axum feature
+axum = { version = "0.8.1", optional = true }
 
 [dev-dependencies]
 axum = "0.7.9"
 http = "1.1.0"
 hyper = { version = "1.5.1", features = ["client", "http1", "http2", "server"] }
 tower = { version = "0.5.1", features = ["full"] }
+
+[features]
+axum = ["dep:axum"]
 
 [lib]
 name = "oyster"

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -26,7 +26,6 @@ tokio = { version = "1", features = ["full"] }
 axum = { version = "0.8.1", optional = true }
 
 [dev-dependencies]
-axum = "0.7.9"
 http = "1.1.0"
 hyper = { version = "1.5.1", features = ["client", "http1", "http2", "server"] }
 tower = { version = "0.5.1", features = ["full"] }

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.14.1"
+version = "0.14.2"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -28,7 +28,6 @@ axum = { version = "0.8.1", optional = true }
 [dev-dependencies]
 http = "1.1.0"
 hyper = { version = "1.5.1", features = ["client", "http1", "http2", "server"] }
-tower = { version = "0.5.1", features = ["full"] }
 
 [features]
 axum = ["dep:axum"]

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -52,6 +52,7 @@ path = "examples/hyper.rs"
 [[example]]
 name = "axum"
 path = "examples/axum.rs"
+required-features = ["axum"]
 
 [profile.release]
 strip = true

--- a/sdks/rs/Cargo.toml
+++ b/sdks/rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oyster-sdk"
-version = "0.14.0"
+version = "0.14.1"
 edition = "2021"
 description = "Oyster SDK"
 license = "Apache-2.0"

--- a/sdks/rs/examples/axum.rs
+++ b/sdks/rs/examples/axum.rs
@@ -30,20 +30,22 @@ struct AuthStore {
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&mut self, key: &Key) -> ContainsResponse {
-        if self.store.contains_key(key) {
-            ContainsResponse::Approved
+    type State = Pcrs;
+
+    fn contains(&mut self, key: &Key) -> ContainsResponse<Pcrs> {
+        if let Some(pcrs) = self.store.get(key) {
+            ContainsResponse::Approved(pcrs.to_owned())
         } else {
             ContainsResponse::NotFound
         }
     }
 
-    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Pcrs> {
         if attestation == b"good auth" {
             self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
-            true
+            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
         } else {
-            false
+            None
         }
     }
 }

--- a/sdks/rs/examples/axum.rs
+++ b/sdks/rs/examples/axum.rs
@@ -1,6 +1,4 @@
 // Axum based example for the scallop transport
-// Sadly, the only real axum usage here is for the router
-// We end up having to repeat the connection loop in order to wrap the underlying stream
 
 use std::collections::HashMap;
 use std::error::Error;

--- a/sdks/rs/examples/axum.rs
+++ b/sdks/rs/examples/axum.rs
@@ -12,14 +12,12 @@ use http::{Request, StatusCode};
 use http_body_util::BodyExt;
 use http_body_util::Empty;
 use hyper::body::Bytes;
-use hyper::body::Incoming;
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::TokioIo;
 use libsodium_sys::{
     crypto_sign_ed25519_pk_to_curve25519, crypto_sign_ed25519_sk_to_curve25519, crypto_sign_keypair,
 };
 use tokio::net::{TcpListener, TcpStream};
 use tokio::time::sleep;
-use tower::Service;
 
 pub use oyster::axum::*;
 pub use oyster::scallop::*;
@@ -72,8 +70,8 @@ async fn welcome() -> &'static str {
 }
 
 async fn server_task(key: Key) -> Result<(), Box<dyn Error + Send + Sync>> {
-    let mut auth_store = AuthStore::default();
-    let mut auther = Auther {};
+    let auth_store = AuthStore::default();
+    let auther = Auther {};
 
     let app = Router::new()
         .route("/hello", get(hello))

--- a/sdks/rs/examples/axum.rs
+++ b/sdks/rs/examples/axum.rs
@@ -62,8 +62,8 @@ impl ScallopAuther for Auther {
     }
 }
 
-async fn hello(ConnectInfo(info): ConnectInfo<Pcrs>) -> &'static str {
-    println!("Pcrs: {:?}", info);
+async fn hello(ConnectInfo(info): ConnectInfo<ScallopState<Pcrs>>) -> &'static str {
+    println!("Pcrs: {:?}", info.0);
     "Hello World!"
 }
 

--- a/sdks/rs/examples/hyper.rs
+++ b/sdks/rs/examples/hyper.rs
@@ -27,20 +27,22 @@ struct AuthStore {
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&mut self, key: &Key) -> ContainsResponse {
-        if self.store.contains_key(key) {
-            ContainsResponse::Approved
+    type State = Pcrs;
+
+    fn contains(&mut self, key: &Key) -> ContainsResponse<Pcrs> {
+        if let Some(pcrs) = self.store.get(key) {
+            ContainsResponse::Approved(pcrs.to_owned())
         } else {
             ContainsResponse::NotFound
         }
     }
 
-    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Pcrs> {
         if attestation == b"good auth" {
             self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
-            true
+            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
         } else {
-            false
+            None
         }
     }
 }

--- a/sdks/rs/examples/scallop.rs
+++ b/sdks/rs/examples/scallop.rs
@@ -19,20 +19,22 @@ struct AuthStore {
 }
 
 impl ScallopAuthStore for AuthStore {
-    fn contains(&mut self, key: &Key) -> ContainsResponse {
-        if self.store.contains_key(key) {
-            ContainsResponse::Approved
+    type State = Pcrs;
+
+    fn contains(&mut self, key: &Key) -> ContainsResponse<Pcrs> {
+        if let Some(pcrs) = self.store.get(key) {
+            ContainsResponse::Approved(pcrs.to_owned())
         } else {
             ContainsResponse::NotFound
         }
     }
 
-    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Pcrs> {
         if attestation == b"good auth" {
             self.store.insert(key, [[1u8; 48], [2u8; 48], [3u8; 48]]);
-            true
+            Some([[1u8; 48], [2u8; 48], [3u8; 48]])
         } else {
-            false
+            None
         }
     }
 }

--- a/sdks/rs/src/attestation.rs
+++ b/sdks/rs/src/attestation.rs
@@ -42,6 +42,7 @@ pub struct AttestationExpectations {
     // (max age, current timestamp)
     pub age: Option<(usize, usize)>,
     pub pcrs: Option<[[u8; 48]; 3]>,
+    pub user_data: Option<Vec<u8>>,
     pub root_public_key: Option<Vec<u8>>,
 }
 
@@ -104,6 +105,15 @@ pub fn verify(
 
     // return the user data
     result.user_data = parse_user_data(&mut attestation_doc)?;
+
+    // check user data if exists
+    if let Some(user_data) = expectations.user_data {
+        if result.user_data != user_data {
+            return Err(AttestationError::VerifyFailed(
+                "user data mismatch".into(),
+            ));
+        }
+    }
 
     Ok(result)
 }

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -10,12 +10,9 @@ use axum::{
 };
 use tokio::net::{TcpListener, TcpStream};
 
-use crate::{
-    attestation::{self, AttestationExpectations, AWS_ROOT_KEY},
-    scallop::{
-        new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, Key, ScallopAuthStore, ScallopAuther,
-        ScallopStream,
-    },
+use crate::scallop::{
+    new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, Key, ScallopAuthStore, ScallopAuther,
+    ScallopStream,
 };
 
 #[derive(Debug, thiserror::Error)]

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -16,7 +16,6 @@ use oyster::{
     },
 };
 use tokio::net::{TcpListener, TcpStream};
-use tracing::error;
 
 #[derive(Debug, thiserror::Error)]
 pub enum AxumError {}
@@ -117,7 +116,7 @@ impl Listener for ScallopListener {
         loop {
             match self.accept_impl().await {
                 Ok(res) => return res,
-                Err(e) => error!("{e:?}"),
+                Err(e) => {} // nothing, maybe log?
             }
         }
     }

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -48,15 +48,13 @@ where
     }
 }
 
-type ListenerIo<AuthStore> = ScallopStream<TcpStream, <AuthStore as ScallopAuthStore>::State>;
-
 impl<AuthStore, Auther> Listener for ScallopListener<AuthStore, Auther>
 where
     AuthStore: ScallopAuthStore + Clone + Send + 'static,
     AuthStore::State: Send + Unpin,
     Auther: ScallopAuther + Clone + 'static,
 {
-    type Io = ListenerIo<AuthStore>;
+    type Io = ScallopStream<TcpStream, <AuthStore as ScallopAuthStore>::State>;
     type Addr = SocketAddr;
 
     async fn accept(&mut self) -> (Self::Io, Self::Addr) {

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -8,14 +8,15 @@ use axum::{
     extract::connect_info::Connected,
     serve::{IncomingStream, Listener},
 };
-use oyster::{
+use tokio::net::{TcpListener, TcpStream};
+
+use crate::{
     attestation::{self, AttestationExpectations, AWS_ROOT_KEY},
     scallop::{
         new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, Key, ScallopAuthStore, ScallopAuther,
         ScallopStream,
     },
 };
-use tokio::net::{TcpListener, TcpStream};
 
 #[derive(Debug, thiserror::Error)]
 pub enum AxumError {}

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -21,7 +21,7 @@ use crate::{
 #[derive(Debug, thiserror::Error)]
 pub enum AxumError {}
 
-pub struct ScallopListener {
+pub struct ScallopListener<AuthStore: ScallopAuthStore, Auther: ScallopAuther> {
     pub listener: TcpListener,
     pub secret: [u8; 32],
     pub auth_store: AuthStore,

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -117,7 +117,7 @@ impl Listener for ScallopListener {
         loop {
             match self.accept_impl().await {
                 Ok(res) => return res,
-                Err(e) => {} // nothing, maybe log?
+                Err(_) => {} // nothing, maybe log?
             }
         }
     }

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -1,0 +1,133 @@
+use std::{
+    net::SocketAddr,
+    ops::Deref,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use anyhow::{Context, Result};
+use axum::{
+    extract::connect_info::Connected,
+    serve::{IncomingStream, Listener},
+};
+use oyster::{
+    attestation::{self, AttestationExpectations, AWS_ROOT_KEY},
+    scallop::{
+        new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, Key, ScallopAuthStore, ScallopAuther,
+        ScallopStream,
+    },
+};
+use tokio::net::{TcpListener, TcpStream};
+use tracing::error;
+
+#[derive(Clone, Default)]
+pub struct AuthStore {}
+
+type AuthStoreState = ([[u8; 48]; 3], Box<[u8]>);
+
+impl ScallopAuthStore for AuthStore {
+    type State = AuthStoreState;
+
+    fn verify(&mut self, attestation: &[u8], _key: Key) -> Option<Self::State> {
+        let Ok(now) = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|x| x.as_millis() as usize)
+        else {
+            return None;
+        };
+
+        let Ok(decoded) = attestation::verify(
+            attestation.to_vec(),
+            AttestationExpectations {
+                age: Some((300000, now)),
+                root_public_key: Some(AWS_ROOT_KEY.to_vec()),
+                // do not care about PCRs, will derive different keys for each set
+                ..Default::default()
+            },
+        ) else {
+            return None;
+        };
+
+        return Some((decoded.pcrs, decoded.user_data.into_boxed_slice()));
+    }
+}
+
+#[derive(Clone)]
+pub struct Auther {
+    pub url: String,
+}
+
+impl ScallopAuther for Auther {
+    type Error = anyhow::Error;
+
+    async fn new_auth(&mut self) -> Result<Box<[u8]>> {
+        let body = reqwest::get(&self.url)
+            .await
+            .context("failed to fetch attestation")?
+            .bytes()
+            .await
+            .context("failed to read attestation")?;
+        Ok(body.deref().into())
+    }
+}
+
+pub struct ScallopListener {
+    pub listener: TcpListener,
+    pub secret: [u8; 32],
+    pub auth_store: AuthStore,
+    pub auther: Auther,
+}
+
+impl ScallopListener {
+    async fn accept_impl(
+        &mut self,
+    ) -> Result<(
+        <ScallopListener as Listener>::Io,
+        <ScallopListener as Listener>::Addr,
+    )> {
+        let (stream, addr) = self
+            .listener
+            .accept()
+            .await
+            .context("failed to accept conns")?;
+        let stream = new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b(
+            stream,
+            &self.secret,
+            Some(self.auth_store.clone()),
+            Some(self.auther.clone()),
+        )
+        .await
+        .context("failed to scallop")?;
+
+        Ok((stream, addr))
+    }
+}
+
+type ListenerIo = ScallopStream<TcpStream, AuthStoreState>;
+
+impl Listener for ScallopListener {
+    type Io = ListenerIo;
+    type Addr = SocketAddr;
+
+    async fn accept(&mut self) -> (Self::Io, Self::Addr) {
+        loop {
+            match self.accept_impl().await {
+                Ok(res) => return res,
+                Err(e) => error!("{e:?}"),
+            }
+        }
+    }
+
+    fn local_addr(&self) -> tokio::io::Result<Self::Addr> {
+        self.listener.local_addr()
+    }
+}
+
+#[derive(Clone)]
+pub struct ScallopState(pub Option<AuthStoreState>);
+
+impl Connected<IncomingStream<'_, ScallopListener>> for ScallopState {
+    fn connect_info(stream: IncomingStream<'_, ScallopListener>) -> Self {
+        // is it possible to avoid a clone here?
+        ScallopState(stream.io().state.clone())
+    }
+}

--- a/sdks/rs/src/axum.rs
+++ b/sdks/rs/src/axum.rs
@@ -1,8 +1,4 @@
-use std::{
-    net::SocketAddr,
-    ops::Deref,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use std::net::SocketAddr;
 
 use axum::{
     extract::connect_info::Connected,
@@ -11,7 +7,7 @@ use axum::{
 use tokio::net::{TcpListener, TcpStream};
 
 use crate::scallop::{
-    new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, Key, ScallopAuthStore, ScallopAuther,
+    new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b, ScallopAuthStore, ScallopAuther,
     ScallopError, ScallopStream,
 };
 

--- a/sdks/rs/src/lib.rs
+++ b/sdks/rs/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod attestation;
+#[cfg(feature = "axum")]
+pub mod axum;
 pub mod scallop;

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -221,9 +221,13 @@ impl ScallopAuthStore for () {
     }
 }
 
-pub trait ScallopAuther {
+// Send bound not ideal
+// Investigate both Send and non-Send versions
+pub trait ScallopAuther: Send {
     type Error: std::fmt::Debug;
-    fn new_auth(&mut self) -> impl std::future::Future<Output = Result<Box<[u8]>, Self::Error>>;
+    fn new_auth(
+        &mut self,
+    ) -> impl std::future::Future<Output = Result<Box<[u8]>, Self::Error>> + Send;
 }
 
 impl<T: ScallopAuther> ScallopAuther for &mut T {

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -193,7 +193,7 @@ pub trait ScallopAuthStore {
     fn contains(&mut self, _key: &Key) -> ContainsResponse<Self::State> {
         ContainsResponse::NotFound
     }
-    fn verify(&mut self, attestation: &[u8], key: Key) -> bool;
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Self::State>;
 }
 
 impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
@@ -203,7 +203,7 @@ impl<T: ScallopAuthStore> ScallopAuthStore for &mut T {
         (**self).contains(key)
     }
 
-    fn verify(&mut self, attestation: &[u8], key: Key) -> bool {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Self::State> {
         (**self).verify(attestation, key)
     }
 }
@@ -216,7 +216,7 @@ impl ScallopAuthStore for () {
         unimplemented!()
     }
 
-    fn verify(&mut self, _attestation: &[u8], _key: Key) -> bool {
+    fn verify(&mut self, _attestation: &[u8], _key: Key) -> Option<Self::State> {
         unimplemented!()
     }
 }

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -420,6 +420,8 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     }
 
     // start tracking what state should go in the stream
+    // it is expected to be set if contains returns state
+    // or verify returns state
     let mut state = None::<AS::State>;
 
     let should_ask_auth = contains == Some(ContainsResponse::NotFound);
@@ -531,13 +533,16 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         }
 
         // verify
-        if !auth_store
+        let Some(_state) = auth_store
             .as_mut()
             .unwrap()
             .verify(&noise_buf[2..len], remote_static)
-        {
+        else {
             return Err(ScallopError::ProtocolError("invalid attestation".into()));
         };
+
+        // set state
+        state = Some(_state)
     }
 
     //---- <- SERVERFIN end ----//

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -351,8 +351,8 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     // will not respond to auth requests if None
     auther: Option<impl ScallopAuther>,
 ) -> Result<ScallopStream<Base, AS::State>, ScallopError> {
-    let mut buf = [0u8; 1024];
-    let mut noise_buf = [0u8; 1024];
+    let mut buf = vec![0u8; 65000].into_boxed_slice();
+    let mut noise_buf = vec![0u8; 65000].into_boxed_slice();
 
     let prologue = b"NoiseSocketInit1\x00\x00";
 
@@ -484,10 +484,6 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
             return Err(ScallopError::ProtocolError("auth payload too big".into()));
         }
 
-        // new heap allocated buffers
-        let mut buf = vec![0u8; 65000].into_boxed_slice();
-        let mut noise_buf = vec![0u8; 65000].into_boxed_slice();
-
         send_CLIENTFIN(
             &mut noise,
             &mut stream,
@@ -520,10 +516,6 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     // payload
 
     if should_ask_auth {
-        // new heap allocated buffers
-        let mut buf = vec![0u8; 65000].into_boxed_slice();
-        let mut noise_buf = vec![0u8; 65000].into_boxed_slice();
-
         // read and handle handshake message
         let len = noise_read(&mut noise, &mut stream, &mut buf, &mut noise_buf).await?;
 
@@ -586,8 +578,8 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     // will not respond to auth requests if None
     auther: Option<impl ScallopAuther>,
 ) -> Result<ScallopStream<Base, AS::State>, ScallopError> {
-    let mut buf = [0u8; 1024];
-    let mut noise_buf = [0u8; 1024];
+    let mut buf = vec![0u8; 65000].into_boxed_slice();
+    let mut noise_buf = vec![0u8; 65000].into_boxed_slice();
 
     let prologue = b"NoiseSocketInit1\x00\x00";
 
@@ -748,10 +740,6 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         if payload.len() > 60000 {
             return Err(ScallopError::ProtocolError("auth payload too big".into()));
         }
-
-        // new heap allocated buffers
-        let mut buf = vec![0u8; 65000].into_boxed_slice();
-        let mut noise_buf = vec![0u8; 65000].into_boxed_slice();
 
         // safe to cast since range has been checked above
         noise_buf[0..2].copy_from_slice(&(payload.len() as u16).to_be_bytes());

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -548,8 +548,6 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
 
     //---- <- SERVERFIN end ----//
 
-    // at this point, one of the below is true
-    // contains is either None
     Ok(ScallopStream {
         noise,
         stream,

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -302,6 +302,11 @@ async fn noise_read(
     // read noise message length
     let len = stream.read_u16().await? as usize;
 
+    // check if buffer is big enough
+    if len > src.len() {
+        return Err(ScallopError::ProtocolError("message too big".into()));
+    }
+
     // read handshake message
     stream.read_exact(&mut src[0..len]).await?;
 

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -238,7 +238,7 @@ impl ScallopAuther for () {
 }
 
 #[derive(Debug)]
-pub struct ScallopStream<Stream: AsyncWrite + AsyncRead + Unpin> {
+pub struct ScallopStream<Stream: AsyncWrite + AsyncRead + Unpin, State = ()> {
     noise: TransportState,
     stream: Stream,
 
@@ -253,6 +253,9 @@ pub struct ScallopStream<Stream: AsyncWrite + AsyncRead + Unpin> {
     wbuf: Box<[u8]>,
     write_start: usize,
     write_end: usize,
+
+    // extra connection state from the AuthStore if any
+    pub state: Option<State>,
 }
 
 trait Noiser {
@@ -535,6 +538,7 @@ pub async fn new_client_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         wbuf: vec![].into_boxed_slice(),
         write_start: 0,
         write_end: 0,
+        state: None,
     })
 }
 
@@ -731,6 +735,7 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
         wbuf: vec![].into_boxed_slice(),
         write_start: 0,
         write_end: 0,
+        state: None,
     })
 }
 

--- a/sdks/rs/src/scallop.rs
+++ b/sdks/rs/src/scallop.rs
@@ -777,7 +777,7 @@ pub async fn new_server_async_Noise_IX_25519_ChaChaPoly_BLAKE2b<
     })
 }
 
-impl<Base: AsyncWrite + AsyncRead + Unpin> ScallopStream<Base> {
+impl<Base: AsyncWrite + AsyncRead + Unpin, State> ScallopStream<Base, State> {
     pub fn get_remote_static(&self) -> Option<[u8; 32]> {
         self.noise
             .get_remote_static()
@@ -785,7 +785,7 @@ impl<Base: AsyncWrite + AsyncRead + Unpin> ScallopStream<Base> {
     }
 }
 
-impl<Base: AsyncWrite + AsyncRead + Unpin> AsyncRead for ScallopStream<Base> {
+impl<Base: AsyncWrite + AsyncRead + Unpin, State: Unpin> AsyncRead for ScallopStream<Base, State> {
     // IMPORTANT: Return Pending only as a direct result of base returning Pending
     // Ensures wakers are set up correctly
     fn poll_read(
@@ -856,7 +856,7 @@ impl<Base: AsyncWrite + AsyncRead + Unpin> AsyncRead for ScallopStream<Base> {
     }
 }
 
-impl<Base: AsyncWrite + AsyncRead + Unpin> AsyncWrite for ScallopStream<Base> {
+impl<Base: AsyncWrite + AsyncRead + Unpin, State: Unpin> AsyncWrite for ScallopStream<Base, State> {
     // IMPORTANT: Return Pending only as a direct result of base returning Pending
     // Ensures wakers are set up correctly
     fn poll_write(


### PR DESCRIPTION
- Scallop streams can hold some state about the connection (e.g. PCRs of the other side)
- Scallop is cleanly integrated with Axum since it supports generic transports now
- Fixed a few crashes in scallop
- Attestation module can also verify user data