### PR TITLE
Add pubkey checks

### DIFF
--- a/kms/derive-server/Cargo.lock
+++ b/kms/derive-server/Cargo.lock
@@ -1638,9 +1638,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12172b8881b95b6d780dc74ee382ed7c1fc4d6d00e6a7c573765743101f4439d"
+checksum = "ea3ab95ef8b1bef15a0327e564df480ffce3d7f47997f36715d0bdc3b1741b56"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "chrono",

--- a/kms/derive-server/Cargo.toml
+++ b/kms/derive-server/Cargo.toml
@@ -13,7 +13,7 @@ http-body-util = "0.1.2"
 hyper = { version = "1.5.2", features = ["full"] }
 hyper-util = { version = "0.1.10", features = ["tokio"] }
 kms-derive-utils = { version = "0.1.0", path = "../derive-utils" }
-oyster-sdk = "0.14.4"
+oyster-sdk = "0.15.0"
 reqwest = "0.12.12"
 serde = { version = "1.0.217", features = ["derive"] }
 tokio = { version = "1.43.0", features = ["full"] }

--- a/kms/derive-server/src/scallop.rs
+++ b/kms/derive-server/src/scallop.rs
@@ -17,7 +17,7 @@ pub struct AuthStore {
 impl ScallopAuthStore for AuthStore {
     type State = ();
 
-    fn verify(&mut self, attestation: &[u8], _key: Key) -> Option<Self::State> {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Self::State> {
         let Ok(now) = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|x| x.as_millis() as usize)
@@ -33,6 +33,7 @@ impl ScallopAuthStore for AuthStore {
                 root_public_key: Some(&AWS_ROOT_KEY),
                 pcrs: Some(self.state.0),
                 user_data: Some(&self.state.1),
+                public_key: Some(&key),
                 ..Default::default()
             },
         ) else {

--- a/kms/derive-server/src/scallop.rs
+++ b/kms/derive-server/src/scallop.rs
@@ -26,13 +26,13 @@ impl ScallopAuthStore for AuthStore {
         };
 
         let Ok(_) = attestation::verify(
-            attestation.to_vec(),
+            attestation,
             AttestationExpectations {
                 // TODO: hardcoded, make it a param
                 age: Some((300000, now)),
-                root_public_key: Some(AWS_ROOT_KEY.to_vec()),
+                root_public_key: Some(&AWS_ROOT_KEY),
                 pcrs: Some(self.state.0),
-                user_data: Some(self.state.1.to_vec()),
+                user_data: Some(&self.state.1),
                 ..Default::default()
             },
         ) else {

--- a/kms/root-server/Cargo.lock
+++ b/kms/root-server/Cargo.lock
@@ -3179,9 +3179,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "oyster-sdk"
-version = "0.14.4"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12172b8881b95b6d780dc74ee382ed7c1fc4d6d00e6a7c573765743101f4439d"
+checksum = "ea3ab95ef8b1bef15a0327e564df480ffce3d7f47997f36715d0bdc3b1741b56"
 dependencies = [
  "aws-nitro-enclaves-cose",
  "axum",

--- a/kms/root-server/Cargo.toml
+++ b/kms/root-server/Cargo.toml
@@ -15,7 +15,7 @@ clap = { version = "4.5.26", features = ["derive"] }
 hex = "0.4.3"
 kms-derive-utils = { version = "0.1.0", path = "../derive-utils" }
 nucypher-core = "0.14.0"
-oyster-sdk = { version = "0.14.4", features = ["axum"] }
+oyster-sdk = { version = "0.15.0", features = ["axum"] }
 rand = "0.8.5"
 reqwest = "0.12.12"
 serde = { version = "1.0.217", features = ["derive"] }

--- a/kms/root-server/src/scallop.rs
+++ b/kms/root-server/src/scallop.rs
@@ -26,12 +26,13 @@ impl ScallopAuthStore for AuthStore {
         };
 
         let Ok(decoded) = attestation::verify(
-            attestation.to_vec(),
+            attestation,
             AttestationExpectations {
                 // TODO: hardcoded, make it a param
                 age: Some((300000, now)),
-                root_public_key: Some(AWS_ROOT_KEY.to_vec()),
-                // do not care about PCRs, will derive different keys for each set
+                root_public_key: Some(&AWS_ROOT_KEY),
+                // do not care about PCRs or user data
+                // will derive different keys for each set
                 ..Default::default()
             },
         ) else {
@@ -42,7 +43,7 @@ impl ScallopAuthStore for AuthStore {
             return None;
         }
 
-        return Some((decoded.pcrs, decoded.user_data.into_boxed_slice()));
+        return Some((decoded.pcrs, decoded.user_data));
     }
 }
 

--- a/kms/root-server/src/scallop.rs
+++ b/kms/root-server/src/scallop.rs
@@ -17,7 +17,7 @@ pub type AuthStoreState = ([[u8; 48]; 3], Box<[u8]>);
 impl ScallopAuthStore for AuthStore {
     type State = AuthStoreState;
 
-    fn verify(&mut self, attestation: &[u8], _key: Key) -> Option<Self::State> {
+    fn verify(&mut self, attestation: &[u8], key: Key) -> Option<Self::State> {
         let Ok(now) = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .map(|x| x.as_millis() as usize)
@@ -31,6 +31,7 @@ impl ScallopAuthStore for AuthStore {
                 // TODO: hardcoded, make it a param
                 age: Some((300000, now)),
                 root_public_key: Some(&AWS_ROOT_KEY),
+                public_key: Some(&key),
                 // do not care about PCRs or user data
                 // will derive different keys for each set
                 ..Default::default()


### PR DESCRIPTION
The attestation should be bound to the Scallop key. Otherwise, anybody can generate a real attestation and use their own key to set up Scallop.