### PR TITLE
Maintain a termination list to avoid iterating through all jobs over and over

### DIFF
--- a/operator/control-plane/src/enclaver.rs
+++ b/operator/control-plane/src/enclaver.rs
@@ -49,7 +49,6 @@ pub async fn main() -> Result<()> {
         32,
         false,
         &[],
-        &[],
     )
     .await
     .context("could not deploy enclave")?;

--- a/operator/control-plane/src/main.rs
+++ b/operator/control-plane/src/main.rs
@@ -217,6 +217,9 @@ async fn run() -> Result<()> {
         .await
         .context("Failed to fetch chain_id")?;
 
+    // Initialize job registry for terminated jobs
+    let job_registry = market::JobRegistry::new("terminated_jobs.txt".to_string()).await?;
+
     let job_id = market::JobId {
         id: B256::ZERO.encode_hex_with_prefix(),
         operator: cli.provider.clone(),
@@ -257,6 +260,7 @@ async fn run() -> Result<()> {
         address_whitelist,
         address_blacklist,
         job_id,
+        job_registry,
     )
     .instrument(info_span!("main"))
     .await;

--- a/operator/control-plane/src/main.rs
+++ b/operator/control-plane/src/main.rs
@@ -220,6 +220,12 @@ async fn run() -> Result<()> {
     // Initialize job registry for terminated jobs
     let job_registry = market::JobRegistry::new("terminated_jobs.txt".to_string()).await?;
 
+    // Start periodic job registry persistence task
+    let registry_clone = job_registry.clone();
+    tokio::spawn(async move {
+        registry_clone.run_periodic_save(10).await; // Save every 10 seconds
+    });
+
     let job_id = market::JobId {
         id: B256::ZERO.encode_hex_with_prefix(),
         operator: cli.provider.clone(),

--- a/operator/control-plane/src/test.rs
+++ b/operator/control-plane/src/test.rs
@@ -26,7 +26,6 @@ pub struct SpinUpOutcome {
     pub image_url: String,
     pub debug: bool,
     pub init_params: Box<[u8]>,
-    pub extra_init_params: Box<[u8]>,
     pub contract_address: String,
     pub chain_id: String,
     pub instance_id: String,
@@ -126,7 +125,6 @@ impl InfraProvider for TestAws {
         image_url: &str,
         debug: bool,
         init_params: &[u8],
-        extra_init_params: &[u8],
     ) -> Result<()> {
         let res = self.instances.get_key_value(&job.id);
         if let Some(x) = res {
@@ -142,7 +140,6 @@ impl InfraProvider for TestAws {
                 image_url: image_url.to_owned(),
                 debug,
                 init_params: init_params.into(),
-                extra_init_params: extra_init_params.into(),
                 contract_address: job.contract.clone(),
                 chain_id: job.chain.clone(),
                 instance_id: x.1.instance_id.clone(),
@@ -169,7 +166,6 @@ impl InfraProvider for TestAws {
             image_url: image_url.to_owned(),
             debug,
             init_params: init_params.into(),
-            extra_init_params: extra_init_params.into(),
             contract_address: job.contract.clone(),
             chain_id: job.chain.clone(),
             instance_id: instance_metadata.instance_id.clone(),


### PR DESCRIPTION
Not perfect but should fix most of #66 

Also removed extra params entirely since it is no longer used.