### PR TITLE
Fix for no response in dev even after port check

### DIFF
--- a/cli/oyster-serverless/src/commands/dev.rs
+++ b/cli/oyster-serverless/src/commands/dev.rs
@@ -143,6 +143,7 @@ pub async fn run_dev(args: DevArgs) -> Result<()> {
         match tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port)).await {
             Ok(_) => {
                 info!("Container is ready on port {}", port);
+                sleep(Duration::from_millis(500)).await;
                 is_ready = true;
                 break;
             }

--- a/cli/oyster-serverless/src/commands/dev.rs
+++ b/cli/oyster-serverless/src/commands/dev.rs
@@ -143,6 +143,7 @@ pub async fn run_dev(args: DevArgs) -> Result<()> {
         match tokio::net::TcpStream::connect(format!("127.0.0.1:{}", port)).await {
             Ok(_) => {
                 info!("Container is ready on port {}", port);
+                // Without a sleep delay, the request would sometimes fail even after checking if the port was ready (mostly on macs).
                 sleep(Duration::from_millis(500)).await;
                 is_ready = true;
                 break;


### PR DESCRIPTION
Without a sleep delay, the request would sometimes fail even after checking if the port was ready (mostly on macs).

```
ERROR oyster_serverless: Error: Failed to make API request: error sending request for url (http://127.0.0.1:21438/): client error (SendRequest): connection closed before message completed
```