### PR TITLE
Oyster serverless staking

### DIFF
--- a/contracts/contracts/contracts/serverless-v2/Executors.sol
+++ b/contracts/contracts/contracts/serverless-v2/Executors.sol
@@ -12,6 +12,7 @@ import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import "../AttestationAutherUpgradeable.sol";
 import "./tree/TreeMapUpgradeable.sol";
 import "../interfaces/IAttestationVerifier.sol";
+import "../staking/interfaces/IRewardDelegators.sol";
 
 /**
  * @title Executors Contract
@@ -122,6 +123,9 @@ contract Executors is
     uint256 public constant STAKE_ADJUSTMENT_FACTOR = 1e18;
 
     bytes32 public constant JOBS_ROLE = keccak256("JOBS_ROLE");
+    bytes32 public constant OPERATOR_REGISTRY_ROLE = keccak256("OPERATOR_REGISTRY_ROLE");
+
+    IRewardDelegators public immutable REWARD_DELEGATORS;
 
     //-------------------------------- Execution Env start --------------------------------//
 
@@ -143,14 +147,27 @@ contract Executors is
     //-------------------------------- Executor start --------------------------------//
 
     modifier isValidExecutorOwner(address _enclaveAddress, address _owner) {
-        if (executors[_enclaveAddress].owner != _owner) revert ExecutorsInvalidOwner();
+        _isValidExecutorOwner(_enclaveAddress, _owner);
+        _;
+    }
+
+    function _isValidExecutorOwner(address _enclaveAddress, address _owner) internal view {
+        if (executors[_enclaveAddress].owner != _owner) 
+            revert ExecutorsInvalidOwner();
+    }
+
+    modifier isRewardDelegators() {
+        if(_msgSender() != address(REWARD_DELEGATORS))
+            revert ExecutorsInvalidRewardDelegators();
         _;
     }
 
     struct Executor {
         uint256 jobCapacity;
         uint256 activeJobs;
-        uint256 stakeAmount;
+        // uint256 stakeAmount;
+        uint256 rewardAmount;
+        uint256 commission;
         address owner;
         bool draining;
         uint8 env;
@@ -176,7 +193,13 @@ contract Executors is
     /// @param owner The owner of the executor.
     /// @param env The execution environment supported by the enclave.
     /// @param jobCapacity The maximum number of jobs the executor can handle in parallel.
-    event ExecutorRegistered(address indexed enclaveAddress, address indexed owner, uint256 jobCapacity, uint8 env);
+    event ExecutorRegistered(
+        address indexed enclaveAddress,
+        address indexed owner,
+        uint256 jobCapacity,
+        uint8 env,
+        uint256 commission
+    );
 
     /// @notice Emitted when an executor is deregistered.
     /// @param enclaveAddress The address of the enclave.
@@ -200,6 +223,7 @@ contract Executors is
     /// @param removedAmount The amount of stake removed.
     event ExecutorStakeRemoved(address indexed enclaveAddress, uint256 removedAmount);
 
+    error ExecutorsInvalidRewardDelegators();
     /// @notice Thrown when the signature timestamp has expired.
     error ExecutorsSignatureTooOld();
     /// @notice Thrown when the signer of the registration data is invalid.
@@ -256,7 +280,7 @@ contract Executors is
         uint256 _jobCapacity,
         uint256 _signTimestamp,
         bytes memory _signature,
-        uint256 _stakeAmount,
+        uint256 _commission,
         uint8 _env,
         address _owner
     ) internal {
@@ -267,15 +291,17 @@ contract Executors is
         _verifyEnclaveKey(_attestationSignature, _attestation);
 
         // signature check
-        _verifySign(enclaveAddress, _owner, _jobCapacity, _env, _signTimestamp, _signature);
+        _verifySign(enclaveAddress, _owner, _jobCapacity, _env, _commission, _signTimestamp, _signature);
 
-        _register(enclaveAddress, _owner, _jobCapacity, _env);
+        _register(enclaveAddress, _owner, _jobCapacity, _env, _commission);
 
-        // add node to the tree if min stake amount deposited
-        if (_stakeAmount >= MIN_STAKE_AMOUNT)
-            _insert_unchecked(_env, enclaveAddress, uint64(_stakeAmount / STAKE_ADJUSTMENT_FACTOR));
+        REWARD_DELEGATORS.updateOperatorDelegation(enclaveAddress, bytes(""));
 
-        _addStake(enclaveAddress, _stakeAmount);
+        // // add node to the tree if min stake amount deposited
+        // if (_stakeAmount >= MIN_STAKE_AMOUNT)
+        //     _insert_unchecked(_env, enclaveAddress, uint64(_stakeAmount / STAKE_ADJUSTMENT_FACTOR));
+
+        // _addStake(enclaveAddress, _stakeAmount);
     }
 
     function _verifySign(
@@ -283,24 +309,26 @@ contract Executors is
         address _owner,
         uint256 _jobCapacity,
         uint8 _env,
+        uint256 _commission,
         uint256 _signTimestamp,
         bytes memory _signature
     ) internal view {
         if (block.timestamp > _signTimestamp + ATTESTATION_MAX_AGE) revert ExecutorsSignatureTooOld();
 
-        bytes32 hashStruct = keccak256(abi.encode(REGISTER_TYPEHASH, _owner, _jobCapacity, _env, _signTimestamp));
+        bytes32 hashStruct = keccak256(abi.encode(REGISTER_TYPEHASH, _owner, _jobCapacity, _env, _commission, _signTimestamp));
         bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, hashStruct));
         address signer = digest.recover(_signature);
 
         if (signer != _enclaveAddress) revert ExecutorsInvalidSigner();
     }
 
-    function _register(address _enclaveAddress, address _owner, uint256 _jobCapacity, uint8 _env) internal {
+    function _register(address _enclaveAddress, address _owner, uint256 _jobCapacity, uint8 _env, uint256 _commission) internal {
         executors[_enclaveAddress].jobCapacity = _jobCapacity;
         executors[_enclaveAddress].owner = _owner;
         executors[_enclaveAddress].env = _env;
+        executors[_enclaveAddress].commission = _commission;
 
-        emit ExecutorRegistered(_enclaveAddress, _owner, _jobCapacity, _env);
+        emit ExecutorRegistered(_enclaveAddress, _owner, _jobCapacity, _env, _commission);
     }
 
     function _drainExecutor(address _enclaveAddress) internal {
@@ -320,12 +348,13 @@ contract Executors is
 
         executors[_enclaveAddress].draining = false;
 
+        ( , uint256 totalDelegation) = REWARD_DELEGATORS.getTotalDelegation(_enclaveAddress);
         // insert node in the tree
-        if (executorNode.stakeAmount >= MIN_STAKE_AMOUNT && executorNode.activeJobs < executorNode.jobCapacity) {
+        if (totalDelegation >= MIN_STAKE_AMOUNT && executorNode.activeJobs < executorNode.jobCapacity) {
             _insert_unchecked(
                 executorNode.env,
                 _enclaveAddress,
-                uint64(executorNode.stakeAmount / STAKE_ADJUSTMENT_FACTOR)
+                uint64(totalDelegation / STAKE_ADJUSTMENT_FACTOR)
             );
         }
 
@@ -336,95 +365,154 @@ contract Executors is
         if (!executors[_enclaveAddress].draining) revert ExecutorsNotDraining();
         if (executors[_enclaveAddress].activeJobs != 0) revert ExecutorsHasPendingJobs();
 
-        _removeStake(_enclaveAddress, executors[_enclaveAddress].stakeAmount);
+        // _removeStake(_enclaveAddress, executors[_enclaveAddress].stakeAmount);
+        REWARD_DELEGATORS.removeOperatorDelegation(_enclaveAddress, bytes(""));
 
+        // TODO: do we need to delete or mark as deregistered?
         _revokeEnclaveKey(_enclaveAddress);
         delete executors[_enclaveAddress];
 
         emit ExecutorDeregistered(_enclaveAddress);
     }
 
-    function _addExecutorStake(uint256 _amount, address _enclaveAddress) internal {
+    // to be called during (1) operator registration (2) stake updates (delegation, undelegation, withdraw rewards)
+    function updateOperatorSelector(address _enclaveAddress, uint256 _totalDelegation) external {
         Executor memory executorNode = executors[_enclaveAddress];
-        uint256 updatedStake = executorNode.stakeAmount + _amount;
 
         if (
             !executorNode.draining &&
             executorNode.activeJobs < executorNode.jobCapacity &&
-            updatedStake >= MIN_STAKE_AMOUNT
+            _totalDelegation >= MIN_STAKE_AMOUNT
         ) {
             // if prevStake is less than min stake, then insert node in tree, else update the node value in tree
-            _upsert(executorNode.env, _enclaveAddress, uint64(updatedStake / STAKE_ADJUSTMENT_FACTOR));
+            _upsert(executorNode.env, _enclaveAddress, uint64(_totalDelegation / STAKE_ADJUSTMENT_FACTOR));
+        } else {
+            _deleteIfPresent(executorNode.env, _enclaveAddress);
         }
-
-        _addStake(_enclaveAddress, _amount);
     }
 
-    function _removeExecutorStake(uint256 _amount, address _enclaveAddress) internal {
+    function removeOperatorSelector(address _enclaveAddress) external {
         if (!executors[_enclaveAddress].draining) revert ExecutorsNotDraining();
         if (executors[_enclaveAddress].activeJobs != 0) revert ExecutorsHasPendingJobs();
-
-        _removeStake(_enclaveAddress, _amount);
     }
 
-    function _addStake(address _enclaveAddress, uint256 _amount) internal {
-        executors[_enclaveAddress].stakeAmount += _amount;
-        // transfer stake
-        TOKEN.safeTransferFrom(executors[_enclaveAddress].owner, address(this), _amount);
+    // function _addExecutorStake(uint256 _amount, address _enclaveAddress) internal {
+    //     Executor memory executorNode = executors[_enclaveAddress];
+    //     uint256 updatedStake = executorNode.stakeAmount + _amount;
 
-        emit ExecutorStakeAdded(_enclaveAddress, _amount);
-    }
+    //     if (
+    //         !executorNode.draining &&
+    //         executorNode.activeJobs < executorNode.jobCapacity &&
+    //         updatedStake >= MIN_STAKE_AMOUNT
+    //     ) {
+    //         // if prevStake is less than min stake, then insert node in tree, else update the node value in tree
+    //         _upsert(executorNode.env, _enclaveAddress, uint64(updatedStake / STAKE_ADJUSTMENT_FACTOR));
+    //     }
 
-    function _removeStake(address _enclaveAddress, uint256 _amount) internal {
-        executors[_enclaveAddress].stakeAmount -= _amount;
-        // transfer stake
-        TOKEN.safeTransfer(executors[_enclaveAddress].owner, _amount);
+    //     _addStake(_enclaveAddress, _amount);
+    // }
 
-        emit ExecutorStakeRemoved(_enclaveAddress, _amount);
-    }
+    // function _removeExecutorStake(uint256 _amount, address _enclaveAddress) internal {
+    //     if (!executors[_enclaveAddress].draining) revert ExecutorsNotDraining();
+    //     if (executors[_enclaveAddress].activeJobs != 0) revert ExecutorsHasPendingJobs();
+
+    //     _removeStake(_enclaveAddress, _amount);
+    // }
+
+    // function _addStake(address _enclaveAddress, uint256 _amount) internal {
+    //     executors[_enclaveAddress].stakeAmount += _amount;
+    //     // transfer stake
+    //     TOKEN.safeTransferFrom(executors[_enclaveAddress].owner, address(this), _amount);
+
+    //     emit ExecutorStakeAdded(_enclaveAddress, _amount);
+    // }
+
+    // function _removeStake(address _enclaveAddress, uint256 _amount) internal {
+    //     executors[_enclaveAddress].stakeAmount -= _amount;
+    //     // transfer stake
+    //     TOKEN.safeTransfer(executors[_enclaveAddress].owner, _amount);
+
+    //     emit ExecutorStakeRemoved(_enclaveAddress, _amount);
+    // }
 
     //-------------------------------- internal functions end ----------------------------------//
 
     //-------------------------------- external functions start ----------------------------------//
 
-    /**
-     * @notice Registers a new executor node.
-     * @param _attestationSignature The attestation signature for verification.
-     * @param _attestation The attestation details.
-     * @param _jobCapacity The maximum number of jobs the executor can handle in parallel.
-     * @param _signTimestamp The timestamp when the signature was created.
-     * @param _signature The signature to verify the registration.
-     * @param _stakeAmount The amount of stake to be deposited.
-     * @param _env The execution environment supported by the enclave.
-     */
-    function registerExecutor(
-        bytes memory _attestationSignature,
-        IAttestationVerifier.Attestation memory _attestation,
-        uint256 _jobCapacity,
-        uint256 _signTimestamp,
-        bytes memory _signature,
-        uint256 _stakeAmount,
-        uint8 _env
-    ) external isValidEnv(_env) {
+    // /**
+    //  * @notice Registers a new executor node.
+    //  * @param _attestationSignature The attestation signature for verification.
+    //  * @param _attestation The attestation details.
+    //  * @param _jobCapacity The maximum number of jobs the executor can handle in parallel.
+    //  * @param _signTimestamp The timestamp when the signature was created.
+    //  * @param _signature The signature to verify the registration.
+    //  * @param _stakeAmount The amount of stake to be deposited.
+    //  * @param _env The execution environment supported by the enclave.
+    //  */
+    // function registerExecutor(
+    //     bytes memory _attestationSignature,
+    //     IAttestationVerifier.Attestation memory _attestation,
+    //     uint256 _jobCapacity,
+    //     uint256 _signTimestamp,
+    //     bytes memory _signature,
+    //     uint256 _stakeAmount,
+    //     uint8 _env
+    // ) external isValidEnv(_env) {
+    //     _registerExecutor(
+    //         _attestationSignature,
+    //         _attestation,
+    //         _jobCapacity,
+    //         _signTimestamp,
+    //         _signature,
+    //         _stakeAmount,
+    //         _env,
+    //         _msgSender()
+    //     );
+    // }
+
+    function registerOperator(
+        address _operator,
+        bytes calldata _data
+    ) external onlyRole(OPERATOR_REGISTRY_ROLE) {
+        // decode the data to get the details
+        (
+            bytes memory attestationSignature,
+            IAttestationVerifier.Attestation memory attestation,
+            uint256 jobCapacity,
+            uint256 signTimestamp,
+            bytes memory signature,
+            uint256 stakeAmount,
+            uint8 env
+        ) = abi.decode(_data, (bytes, IAttestationVerifier.Attestation, uint256, uint256, bytes, uint256, uint8));
+
         _registerExecutor(
-            _attestationSignature,
-            _attestation,
-            _jobCapacity,
-            _signTimestamp,
-            _signature,
-            _stakeAmount,
-            _env,
-            _msgSender()
+            attestationSignature,
+            attestation,
+            jobCapacity,
+            signTimestamp,
+            signature,
+            stakeAmount,
+            env,
+            _operator
         );
+
     }
 
-    /**
-     * @notice Deregisters an executor node.
-     * @param _enclaveAddress The address of the executor enclave to deregister.
-     * @dev Caller must be the owner of the executor node.
-     */
-    function deregisterExecutor(address _enclaveAddress) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
-        _deregisterExecutor(_enclaveAddress);
+    // /**
+    //  * @notice Deregisters an executor node.
+    //  * @param _enclaveAddress The address of the executor enclave to deregister.
+    //  * @dev Caller must be the owner of the executor node.
+    //  */
+    // function deregisterExecutor(address _enclaveAddress) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
+    //     _deregisterExecutor(_enclaveAddress);
+    // }
+
+    function deregisterOperator(address _operator, bytes memory _data) external onlyRole(OPERATOR_REGISTRY_ROLE) {
+        // decode the data to get the enclave address
+        address enclaveAddress = abi.decode(_data, (address));
+        _isValidExecutorOwner(enclaveAddress, _operator);
+
+        _deregisterExecutor(enclaveAddress);
     }
 
     /**
@@ -436,6 +524,14 @@ contract Executors is
         _drainExecutor(_enclaveAddress);
     }
 
+    function drainOperator(address _operator, bytes memory _data) external onlyRole(OPERATOR_REGISTRY_ROLE) {
+        // decode the data to get the enclave address
+        address enclaveAddress = abi.decode(_data, (address));
+        _isValidExecutorOwner(enclaveAddress, _operator);
+
+        _drainExecutor(enclaveAddress);
+    }
+
     /**
      * @notice Revives a previously drained executor node.
      * @param _enclaveAddress The address of the executor enclave to revive.
@@ -445,31 +541,31 @@ contract Executors is
         _reviveExecutor(_enclaveAddress);
     }
 
-    /**
-     * @notice Adds stake to an executor node.
-     * @param _enclaveAddress The address of the executor enclave to add stake to.
-     * @param _amount The amount of stake to add.
-     * @dev Caller must be the owner of the executor node.
-     */
-    function addExecutorStake(
-        address _enclaveAddress,
-        uint256 _amount
-    ) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
-        _addExecutorStake(_amount, _enclaveAddress);
-    }
+    // /**
+    //  * @notice Adds stake to an executor node.
+    //  * @param _enclaveAddress The address of the executor enclave to add stake to.
+    //  * @param _amount The amount of stake to add.
+    //  * @dev Caller must be the owner of the executor node.
+    //  */
+    // function addExecutorStake(
+    //     address _enclaveAddress,
+    //     uint256 _amount
+    // ) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
+    //     _addExecutorStake(_amount, _enclaveAddress);
+    // }
 
-    /**
-     * @notice Removes stake from an executor node.
-     * @param _enclaveAddress The address of the executor enclave to remove stake from.
-     * @param _amount The amount of stake to remove.
-     * @dev Caller must be the owner of the executor node.
-     */
-    function removeExecutorStake(
-        address _enclaveAddress,
-        uint256 _amount
-    ) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
-        _removeExecutorStake(_amount, _enclaveAddress);
-    }
+    // /**
+    //  * @notice Removes stake from an executor node.
+    //  * @param _enclaveAddress The address of the executor enclave to remove stake from.
+    //  * @param _amount The amount of stake to remove.
+    //  * @dev Caller must be the owner of the executor node.
+    //  */
+    // function removeExecutorStake(
+    //     address _enclaveAddress,
+    //     uint256 _amount
+    // ) external isValidExecutorOwner(_enclaveAddress, _msgSender()) {
+    //     _removeExecutorStake(_amount, _enclaveAddress);
+    // }
 
     /**
      * @notice Allows only verified addresses to perform certain actions.
@@ -522,10 +618,11 @@ contract Executors is
     function _releaseExecutor(address _enclaveAddress) internal {
         if (!executors[_enclaveAddress].draining) {
             uint8 env = executors[_enclaveAddress].env;
+            ( , uint256 totalDelegation) = REWARD_DELEGATORS.getTotalDelegation(_enclaveAddress);
             // node might have been deleted due to max job capacity reached
             // if stakes are greater than minStakes then update the stakes for executors in tree if it already exists else add with latest stake
-            if (executors[_enclaveAddress].stakeAmount >= MIN_STAKE_AMOUNT)
-                _upsert(env, _enclaveAddress, uint64(executors[_enclaveAddress].stakeAmount / STAKE_ADJUSTMENT_FACTOR));
+            if (totalDelegation >= MIN_STAKE_AMOUNT)
+                _upsert(env, _enclaveAddress, uint64(totalDelegation / STAKE_ADJUSTMENT_FACTOR));
                 // remove node from tree if stake falls below min level
             else _deleteIfPresent(env, _enclaveAddress);
         }
@@ -534,8 +631,9 @@ contract Executors is
     }
 
     function _slashExecutor(address _enclaveAddress, address _recipient) internal returns (uint256) {
-        uint256 totalComp = (executors[_enclaveAddress].stakeAmount * SLASH_PERCENT_IN_BIPS) / SLASH_MAX_BIPS;
-        executors[_enclaveAddress].stakeAmount -= totalComp;
+        ( , uint256 totalDelegation) = REWARD_DELEGATORS.getTotalDelegation(_enclaveAddress);
+        uint256 totalComp = (totalDelegation * SLASH_PERCENT_IN_BIPS) / SLASH_MAX_BIPS;
+        // executors[_enclaveAddress].stakeAmount -= totalComp;
 
         TOKEN.safeTransfer(_recipient, totalComp);
 
@@ -579,6 +677,26 @@ contract Executors is
      */
     function slashExecutor(address _enclaveAddress) external onlyRole(JOBS_ROLE) returns (uint256) {
         return _slashExecutor(_enclaveAddress, _msgSender());
+    }
+
+    function issueReward(
+        address _enclaveAddress,
+        uint256 _amount
+    ) external onlyRole(JOBS_ROLE) {
+        executors[_enclaveAddress].rewardAmount += _amount;
+    }
+
+    function claimReward(address _enclaveAddress) external isRewardDelegators returns (uint256 reward) {
+        reward = executors[_enclaveAddress].rewardAmount;
+        executors[_enclaveAddress].rewardAmount = 0;
+
+        // transfer payout to the RewardsDelegator contract
+        TOKEN.safeTransfer(_msgSender(), reward);
+    }
+
+    function getRewardInfo(address _executor) external view returns(uint256, address) {
+        Executor storage executor = executors[_executor];
+        return (executor.commission, executor.owner);
     }
 
     //-------------------------------- external functions end ----------------------------------//

--- a/contracts/contracts/contracts/serverless-v2/Jobs.sol
+++ b/contracts/contracts/contracts/serverless-v2/Jobs.sol
@@ -249,6 +249,9 @@ contract Jobs is
     bytes32 private constant SUBMIT_OUTPUT_TYPEHASH =
         keccak256("SubmitOutput(uint256 jobId,bytes output,uint256 totalTime,uint8 errorCode,uint256 signTimestamp)");
 
+    // NEW STORAGE VARS
+    IRewardDelegators public rewardDelegators;
+
     /**
      * @dev Emitted when a new job is created.
      * @param jobId The ID of the job created.
@@ -661,6 +664,4 @@ contract Jobs is
         return jobs[_jobId].selectedExecutors;
     }
 
-    // new vars
-    IRewardDelegators public rewardDelegators;
 }

--- a/contracts/contracts/contracts/staking/interfaces/IRewardDelegators.sol
+++ b/contracts/contracts/contracts/staking/interfaces/IRewardDelegators.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IRewardDelegators {
+    function thresholdForSelection(bytes32 networkId) external returns(uint256);
+    function addRewardFactor(bytes32 _tokenId, uint256 _rewardFactor) external;
+    function removeRewardFactor(bytes32 _tokenId) external;
+    function updateRewardFactor(bytes32 _tokenId, uint256 _updatedRewardFactor) external;
+    function _updateRewards(address _cluster) external;
+    function delegate(
+        address _delegator,
+        address _cluster,
+        bytes32[] calldata _tokens,
+        uint256[] calldata _amounts
+    ) external;
+    function undelegate(
+        address _delegator,
+        address _cluster,
+        bytes32[] calldata _tokens,
+        uint256[] calldata _amounts
+    ) external;
+    function withdrawRewards(address _delegator, address _cluster) external returns(uint256);
+    function getClusterDelegation(address _cluster, bytes32 _tokenId) external view returns(uint256);
+    function getDelegation(address _cluster, address _delegator, bytes32 _tokenId) external view returns(uint256);
+    function updateThresholdForSelection(bytes32 networkId, uint256 thresholdForSelection) external;
+    function updateStakeAddress(address _updatedStakeAddress) external;
+    function updateClusterRewards(address _updatedClusterRewards) external;
+    function updateClusterRegistry(address _updatedClusterRegistry) external;
+    function updatePONDAddress(address _updatedPOND) external;
+    function tokenList(uint256 index) external view returns (bytes32);
+    function getAccRewardPerShare(address _cluster, bytes32 _tokenId) external view returns(uint256);
+    function updateClusterDelegation(address _cluster, bytes32 _networkId) external;
+    function removeClusterDelegation(address _cluster, bytes32 _networkId) external;
+
+    function updateOperatorDelegation(address _operator, bytes memory _data) external;
+    function removeOperatorDelegation(address _operator, bytes memory _data) external;
+
+    function lockTokens(
+        address _operator,
+        bytes32 _lockId,
+        uint256 _amount
+        // bytes32[] memory _tokens,
+        // uint256[] memory _amounts
+    ) external;
+    function unlockTokens(
+        address _operator,
+        bytes32 _lockId
+    ) external;
+    function slash(
+        address _operator,
+        bytes32 _lockId
+    ) external;
+    function getTotalDelegation(
+        address cluster
+    ) external view returns(uint256 _totalWeight, uint256 totalDelegations);
+}

--- a/contracts/staking-contracts/contracts/staking/InflationRewardsEmitter.sol
+++ b/contracts/staking-contracts/contracts/staking/InflationRewardsEmitter.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "./interfaces/IInflationRewardsEmitter.sol";
+import "./interfaces/IInflationRewardsManager.sol";
+
+contract InflationRewardsEmitter is
+    Initializable, // initializer
+    ContextUpgradeable, // _msgSender, _msgData
+    ERC165Upgradeable, // supportsInterface
+    AccessControlUpgradeable, // RBAC
+    AccessControlEnumerableUpgradeable, // RBAC enumeration
+    ERC1967UpgradeUpgradeable, // delegate slots, proxy admin, private upgrade
+    UUPSUpgradeable, // public upgrade,
+    IInflationRewardsEmitter // interface
+{
+    // in case we add more contracts in the inheritance chain
+    uint256[500] private __gap0;
+
+    using SafeERC20 for IERC20;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    // initializes the logic contract without any admins
+    // safeguard against takeover of the logic contract
+    constructor(uint256 _epochLength, uint256 _startTime) initializer {
+        EPOCH_LENGTH = _epochLength;
+        START_TIME = _startTime;
+    }
+
+    modifier onlyAdmin() {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "only admin");
+        _;
+    }
+
+    //-------------------------------- Overrides start --------------------------------//
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165Upgradeable, AccessControlUpgradeable, AccessControlEnumerableUpgradeable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _grantRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._grantRole(role, account);
+    }
+
+    function _revokeRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._revokeRole(role, account);
+
+        // protect against accidentally removing all admins
+        require(getRoleMemberCount(DEFAULT_ADMIN_ROLE) != 0, "Cannot be adminless");
+    }
+
+    function _authorizeUpgrade(address /*account*/) internal view override onlyAdmin {}
+
+    //-------------------------------- Overrides end --------------------------------//
+
+    //-------------------------------- Initializer start --------------------------------//
+
+    uint256[50] private __gap1;
+
+    function initialize(
+        address _rewardToken,
+        address _inflationRewardsManager,
+        uint256 _rewardPerEpoch
+    ) public initializer {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __AccessControlEnumerable_init_unchained();
+        __ERC1967Upgrade_init_unchained();
+        __UUPSUpgradeable_init_unchained();
+
+        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+
+        rewardToken = IERC20(_rewardToken);
+        inflationRewardsManager = _inflationRewardsManager;
+        rewardPerEpoch = _rewardPerEpoch;
+    }
+
+    //-------------------------------- Initializer end --------------------------------//
+
+    // the token to be used for inflationary rewards
+    IERC20 public rewardToken;
+
+    address public inflationRewardsManager;
+
+    uint256 public immutable START_TIME;
+    uint256 public immutable EPOCH_LENGTH;
+
+    uint256 public lastEmittedEpoch;
+
+    uint256 public rewardPerEpoch;
+
+    error InflationRewardsEmitter_OnlyInflationRewardsManager();
+    error InflationRewardsEmitter_AlreadyEmitted();
+
+    modifier onlyInflationRewardsManager() {
+        if(_msgSender() != inflationRewardsManager)
+            revert InflationRewardsEmitter_OnlyInflationRewardsManager();
+        _;
+    }
+
+    function getCurrentEpoch() public view returns (uint256) {
+        return (block.timestamp - START_TIME) / EPOCH_LENGTH;
+    }
+
+    function emitInflationaryReward() external onlyInflationRewardsManager returns (uint256) {
+        uint256 currentEpoch = getCurrentEpoch();
+        if(lastEmittedEpoch < currentEpoch) {
+            lastEmittedEpoch = currentEpoch;
+            rewardToken.transfer(inflationRewardsManager, rewardPerEpoch);
+            return rewardPerEpoch;
+        }
+        revert InflationRewardsEmitter_AlreadyEmitted();
+    }
+
+}

--- a/contracts/staking-contracts/contracts/staking/InflationRewardsManager.sol
+++ b/contracts/staking-contracts/contracts/staking/InflationRewardsManager.sol
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "./interfaces/IInflationRewardsManager.sol";
+import "./interfaces/IRewardDelegators.sol";
+import "./interfaces/IInflationRewardsEmitter.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract InflationRewardsManager is
+    Initializable, // initializer
+    ContextUpgradeable, // _msgSender, _msgData
+    ERC165Upgradeable, // supportsInterface
+    AccessControlUpgradeable, // RBAC
+    AccessControlEnumerableUpgradeable, // RBAC enumeration
+    ERC1967UpgradeUpgradeable, // delegate slots, proxy admin, private upgrade
+    UUPSUpgradeable, // public upgrade,
+    IInflationRewardsManager // interface
+{
+    // in case we add more contracts in the inheritance chain
+    uint256[500] private __gap0;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    // initializes the logic contract without any admins
+    // safeguard against takeover of the logic contract
+    constructor() initializer {}
+
+    modifier onlyAdmin() {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "only admin");
+        _;
+    }
+
+    //-------------------------------- Overrides start --------------------------------//
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165Upgradeable, AccessControlUpgradeable, AccessControlEnumerableUpgradeable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _grantRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._grantRole(role, account);
+    }
+
+    function _revokeRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._revokeRole(role, account);
+
+        // protect against accidentally removing all admins
+        require(getRoleMemberCount(DEFAULT_ADMIN_ROLE) != 0, "Cannot be adminless");
+    }
+
+    function _authorizeUpgrade(address /*account*/) internal view override onlyAdmin {}
+
+    //-------------------------------- Overrides end --------------------------------//
+
+    //-------------------------------- Initializer start --------------------------------//
+
+    uint256[50] private __gap1;
+
+    function initialize(address _rewardDelegators) public initializer {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __AccessControlEnumerable_init_unchained();
+        __ERC1967Upgrade_init_unchained();
+        __UUPSUpgradeable_init_unchained();
+
+        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+
+        rewardDelegators = IRewardDelegators(_rewardDelegators);
+    }
+
+    //-------------------------------- Initializer end --------------------------------//
+
+    IRewardDelegators public rewardDelegators;
+    IInflationRewardsEmitter public inflationRewardsEmitter;
+
+    mapping(address => uint256) public executorEpochJobs;
+    // epoch => total jobs
+    mapping(uint256 => uint256) public totalEpochJobs;
+
+    struct DelegationAmountInfo {
+        mapping(bytes32 tokenId => uint256 amounts) activeDelegation;
+        mapping(bytes32 tokenId => uint256 amounts) pendingDelegation;
+    }
+
+    struct DelegationEpochInfo {
+        uint256 epochActive;
+        uint256 epochPending;
+    }
+
+    struct ExecutorEpochInfo {
+        uint256 lastDistributedEpoch;
+        uint256 lastJobDoneEpoch;
+    }
+
+    // This is updated each time an Executor completes first job of new epoch
+    // Or, this can be manually updated by anyone
+    // executor => epoch => tokenId => amount
+    // mapping (address executor => mapping(uint256 epoch => mapping(bytes32 tokenId => uint256 amount))) executorRewardPerToken;
+    // executor => tokenId => amount
+    mapping (address executor => mapping(bytes32 tokenId => uint256 amount)) executorRewardPerToken;
+
+
+    // Total delegation amounts of each tokenId over all Executors
+    // DelegationAmountInfo totalDelegationInfo;
+
+    // Total delegation amounts of each tokenId of each Executor 
+    mapping (address executor => ExecutorEpochInfo) executorEpochInfo;
+    mapping (address executor => DelegationAmountInfo) executorDelegationInfo;
+
+    // Delegation info of each Delegator
+    mapping (address operator => mapping(address delegator => DelegationEpochInfo)) delegatorDelegationEpochInfo;
+    mapping (address operator => mapping(address delegator => DelegationAmountInfo)) delegatorDelegationInfo;
+    // mapping (address delegator => mapping(bytes32 token => uint256 amount)) delegatorRewardDebt;
+    mapping (address operator => mapping(address delegator => mapping(bytes32 token => uint256 amount))) delegatorRewardDebt;
+
+    // uint256 public activeEpoch;
+    mapping(uint256 epoch => uint256 reward) public epochRewards;
+
+    bytes32 public constant JOBS_ROLE = keccak256("JOBS_ROLE");
+
+    error InflationRewardsManager_OnlyRewardDelegators();
+
+    modifier onlyRewardDelegators() {
+        if(_msgSender() != address(rewardDelegators))
+            revert InflationRewardsManager_OnlyRewardDelegators();
+        _;
+    }
+
+    function setInflationRewardsEmitter(
+        address _inflationRewardsEmitter
+    ) external onlyAdmin {
+        inflationRewardsEmitter = IInflationRewardsEmitter(_inflationRewardsEmitter);
+    }
+
+    function notifyOutputSubmission(
+        address _operator
+    ) external onlyRole(JOBS_ROLE) {
+        bytes32[] memory tokens = rewardDelegators.getTokenList();
+
+        uint256 currentEpoch = inflationRewardsEmitter.getCurrentEpoch();
+        if(currentEpoch > executorEpochInfo[_operator].lastJobDoneEpoch) {
+            _updateRewards(_operator, tokens);
+            _activateOperatorStake(_operator, tokens);
+
+            // executorEpochInfo[_operator].lastDistributedEpoch = executorEpochInfo[_operator].lastJobDoneEpoch;
+            executorEpochInfo[_operator].lastJobDoneEpoch = currentEpoch;
+
+            executorEpochJobs[_operator] = 1;
+            totalEpochJobs[currentEpoch] = 1;
+            // activeEpoch = currentEpoch;
+
+            epochRewards[currentEpoch] = inflationRewardsEmitter.emitInflationaryReward();
+        } else {
+            executorEpochJobs[_operator] += 1;
+            totalEpochJobs[currentEpoch] += 1;
+        }
+    }
+
+    function updateInflationRewards(
+        address _operator,
+        address _delegator,
+        bytes32[] memory _tokens,
+        uint256[] memory _amounts,
+        bool _isDelegation
+    ) external onlyRewardDelegators {
+        _updateTokens(_operator, _delegator, _tokens, _amounts, _isDelegation);
+    }
+
+    // function delegate(
+    //     address _operator,
+    //     address _delegator,
+    //     bytes32[] memory _tokens,
+    //     uint256[] memory _amounts
+    // ) external onlyRewardDelegators {
+    //     _updateTokens(_operator, _delegator, _tokens, _amounts, true);
+    // }
+
+    function _updateTokens(
+        address _operator,
+        address _delegator,
+        bytes32[] memory _tokens,
+        uint256[] memory _amounts,
+        bool _isDelegation
+    ) internal {
+        require(_tokens.length == _amounts.length, "Tokens and amounts length mismatch");
+
+        uint256 currentEpoch = inflationRewardsEmitter.getCurrentEpoch();
+        // checks if it is the first update for the operator in the current epoch
+        bool isFirstEpochUpdate = (currentEpoch > executorEpochInfo[_operator].lastJobDoneEpoch && 
+            executorEpochInfo[_operator].lastJobDoneEpoch != executorEpochInfo[_operator].lastDistributedEpoch);
+
+        if(isFirstEpochUpdate) {
+            // update rewards for the operator till last job done epoch
+            _updateRewards(_operator, _tokens);
+        }
+
+        uint256 reward;
+        for (uint256 i = 0; i < _tokens.length; i++) {
+            bytes32 tokenId = _tokens[i];
+            uint256 amount = _amounts[i];
+
+            // Update executor's delegation amounts
+            _updateExecutorDelegationInfo(_operator, isFirstEpochUpdate, tokenId, amount, _isDelegation);
+
+            // Update delegator's delegation amounts
+            reward += _updateDelegatorDelegationInfo(_operator, _delegator, tokenId, amount, _isDelegation);
+        }
+
+        // delegatorDelegationEpochInfo[_operator][_delegator].epochPending = currentEpoch;
+
+        if(reward != 0) {
+            IERC20 rewardToken = inflationRewardsEmitter.rewardToken();
+            rewardToken.transfer(_delegator, reward);
+        }
+    }
+
+    function _updateExecutorDelegationInfo(
+        address _operator,
+        bool _isFirstEpochUpdate,
+        bytes32 _tokenId,
+        uint256 _amount,
+        bool _isDelegation
+    ) internal {
+        if(_isFirstEpochUpdate) {
+            // Update executor's delegation amounts
+            _activateOperatorTokenStake(_operator, _tokenId);
+            if(_isDelegation) {
+                executorDelegationInfo[_operator].pendingDelegation[_tokenId] = _amount;
+            } else {
+                executorDelegationInfo[_operator].activeDelegation[_tokenId] -= _amount;
+            }
+        } else {
+            if(_isDelegation) {
+                executorDelegationInfo[_operator].pendingDelegation[_tokenId] += _amount;
+            } else {
+                uint256 executorPendingAmount = executorDelegationInfo[_operator].pendingDelegation[_tokenId];
+                uint256 minAmount = _amount < executorPendingAmount ? _amount : executorPendingAmount;
+                executorDelegationInfo[_operator].pendingDelegation[_tokenId] -= minAmount;
+                // If the amount to be undelegated is more than the pending delegation
+                if(_amount - minAmount > 0) {
+                    executorDelegationInfo[_operator].activeDelegation[_tokenId] -= (_amount - minAmount);
+                }
+            }
+        }
+    }
+
+    function _updateDelegatorDelegationInfo(
+        address _operator,
+        address _delegator,
+        bytes32 _tokenId,
+        uint256 _amount,
+        bool _isDelegation
+    ) internal returns (uint256 reward) {
+        uint256 currentEpoch = inflationRewardsEmitter.getCurrentEpoch();
+        if(currentEpoch > delegatorDelegationEpochInfo[_operator][_delegator].epochPending) {
+            uint256 oldBalance = delegatorDelegationInfo[_operator][_delegator].activeDelegation[_tokenId];
+            uint256 newBalance = oldBalance + delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_tokenId];
+
+            // Update delegator's delegation amounts
+            _activateDelegatorTokenStake(_operator, _delegator, _tokenId);
+            
+            if(_isDelegation) {
+                delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_tokenId] = _amount;
+            } else {
+                newBalance -= _amount;
+                delegatorDelegationInfo[_operator][_delegator].activeDelegation[_tokenId] -= _amount;
+            }
+
+            // Update delegator's reward debt
+            reward = _updateDelegatorRewards(_operator, _delegator, _tokenId, oldBalance, newBalance);
+
+            delegatorDelegationEpochInfo[_operator][_delegator].epochPending = currentEpoch;
+        } else {
+            if(_isDelegation) {
+                delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_tokenId] += _amount;
+            } else {
+                uint256 delegatorPendingAmount = delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_tokenId];
+                uint256 minAmount = _amount < delegatorPendingAmount ? _amount : delegatorPendingAmount;
+                delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_tokenId] -= minAmount;
+                // If the _amount to be undelegated is more than the pending delegation
+                if(_amount - minAmount > 0) {
+                    delegatorDelegationInfo[_operator][_delegator].activeDelegation[_tokenId] -= (_amount - minAmount);
+                }
+            }
+        }
+    }
+
+    // Update the rewardPerShare till the lastJobDoneEpoch
+    // to be only called once in an epoch for each executor
+    function _updateRewards(
+        address _operator,
+        bytes32[] memory tokens
+    ) internal {
+        uint256 lastJobDoneEpoch = executorEpochInfo[_operator].lastJobDoneEpoch;
+        uint256 executorReward = epochRewards[lastJobDoneEpoch] * executorEpochJobs[_operator] / 
+                                    totalEpochJobs[lastJobDoneEpoch];
+        if(executorReward == 0)
+            return;
+
+        uint256 delegatedTokens;
+        uint256[] memory tokenDelegations = new uint256[](tokens.length);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            bytes32 tokenId = tokens[i];
+
+            tokenDelegations[i] = executorDelegationInfo[_operator].activeDelegation[tokenId];
+            if(tokenDelegations[i] > 0)
+                ++delegatedTokens;
+        }
+
+        for (uint256 i = 0; i < tokens.length; i++) {
+            bytes32 tokenId = tokens[i];
+            if(tokenDelegations[i] > 0)
+                executorRewardPerToken[_operator][tokenId] += ((executorReward * (10**30) / delegatedTokens) / 
+                                                                tokenDelegations[i]);
+        }
+
+        executorEpochInfo[_operator].lastDistributedEpoch = executorEpochInfo[_operator].lastJobDoneEpoch;
+    }
+
+    function _activateOperatorStake(
+        address _operator,
+        bytes32[] memory tokens
+    ) internal {
+        // Update the executor's delegation amounts
+        for (uint256 i = 0; i < tokens.length; i++) {
+            bytes32 tokenId = tokens[i];
+            _activateOperatorTokenStake(_operator, tokenId);
+        }
+    }
+
+    function _activateOperatorTokenStake(
+        address _operator,
+        bytes32 _token
+    ) internal {
+        executorDelegationInfo[_operator].activeDelegation[_token] += 
+            executorDelegationInfo[_operator].pendingDelegation[_token];
+
+        executorDelegationInfo[_operator].pendingDelegation[_token] = 0;
+    }
+
+    function _activateDelegatorTokenStake(
+        address _operator,
+        address _delegator,
+        bytes32 _token
+    ) internal {
+        delegatorDelegationInfo[_operator][_delegator].activeDelegation[_token] += 
+            delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_token];
+
+        delegatorDelegationInfo[_operator][_delegator].pendingDelegation[_token] = 0;
+    }
+
+    function _updateDelegatorRewards(
+        address _operator,
+        address _delegator,
+        bytes32 _token,
+        uint256 _oldBalance,
+        uint256 _newBalance
+    ) internal returns (uint256 reward) {
+        // update delegation reward debt for the delegator
+
+        // uint256 lastJobDoneEpoch = executorEpochInfo[_operator].lastJobDoneEpoch;
+        // uint256 currentEpoch = inflationRewardsEmitter.getCurrentEpoch();
+        // // No need to update if the last job done epoch is same as current epoch
+        // if(lastJobDoneEpoch == currentEpoch)
+        //     return;
+
+        uint256 operatorAccruedReward = executorRewardPerToken[_operator][_token];
+        uint256 rewardDebt = delegatorRewardDebt[_operator][_delegator][_token];
+
+        uint256 executorReward = operatorAccruedReward * _oldBalance / (10**30);
+        reward = executorReward - rewardDebt;
+
+        delegatorRewardDebt[_operator][_delegator][_token] = operatorAccruedReward * _newBalance / (10**30);
+    }
+
+    // function undelegate(
+    //     address _operator,
+    //     address _delegator,
+    //     bytes32[] memory _tokens,
+    //     uint256[] memory _amounts
+    // ) external onlyRewardDelegators {
+    //     _updateTokens(_operator, _delegator, _tokens, _amounts, false);
+    // }
+
+    // function withdrawRewards(
+    //     address _operator,
+    //     address _delegator,
+    //     uint256[] memory _amounts,
+    //     bytes32[] memory _tokens
+    // ) external onlyRewardDelegators {
+    //     _updateTokens(_operator, _delegator, _tokens, _amounts, true);
+    // }
+
+}

--- a/contracts/staking-contracts/contracts/staking/OperatorRegistry.sol
+++ b/contracts/staking-contracts/contracts/staking/OperatorRegistry.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import "./interfaces/IOperatorRegistry.sol";
+import "./interfaces/IClusterRegistry.sol";
+import "./interfaces/IOperatorManager.sol";
+import "./interfaces/IRewardDelegators.sol";
+
+contract OperatorRegistry is
+    Initializable, // initializer
+    ContextUpgradeable, // _msgSender, _msgData
+    ERC165Upgradeable, // supportsInterface
+    AccessControlUpgradeable, // RBAC
+    AccessControlEnumerableUpgradeable, // RBAC enumeration
+    ERC1967UpgradeUpgradeable, // delegate slots, proxy admin, private upgrade
+    UUPSUpgradeable, // public upgrade,
+    IOperatorRegistry // interface
+{
+    // in case we add more contracts in the inheritance chain
+    uint256[500] private __gap0;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    // initializes the logic contract without any admins
+    // safeguard against takeover of the logic contract
+    constructor() initializer {}
+
+    modifier onlyAdmin() {
+        require(hasRole(DEFAULT_ADMIN_ROLE, _msgSender()), "only admin");
+        _;
+    }
+
+    //-------------------------------- Overrides start --------------------------------//
+
+    function supportsInterface(
+        bytes4 interfaceId
+    ) public view virtual override(ERC165Upgradeable, AccessControlUpgradeable, AccessControlEnumerableUpgradeable) returns (bool) {
+        return super.supportsInterface(interfaceId);
+    }
+
+    function _grantRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._grantRole(role, account);
+    }
+
+    function _revokeRole(
+        bytes32 role,
+        address account
+    ) internal virtual override(AccessControlUpgradeable, AccessControlEnumerableUpgradeable) {
+        super._revokeRole(role, account);
+
+        // protect against accidentally removing all admins
+        require(getRoleMemberCount(DEFAULT_ADMIN_ROLE) != 0, "Cannot be adminless");
+    }
+
+    function _authorizeUpgrade(address /*account*/) internal view override onlyAdmin {}
+
+    //-------------------------------- Overrides end --------------------------------//
+
+    //-------------------------------- Initializer start --------------------------------//
+
+    uint256[50] private __gap1;
+
+    function initialize(address _rewardDelegators) public initializer {
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __AccessControlEnumerable_init_unchained();
+        __ERC1967Upgrade_init_unchained();
+        __UUPSUpgradeable_init_unchained();
+
+        _setupRole(DEFAULT_ADMIN_ROLE, _msgSender());
+
+        _updateRewardDelegators(_rewardDelegators);
+    }
+
+    //-------------------------------- Initializer end --------------------------------//
+
+    //-------------------------------- Admin calls start --------------------------------//
+
+    function updateRewardDelegators(address _updatedRewardDelegators) external onlyAdmin {
+        _updateRewardDelegators(_updatedRewardDelegators);
+    }
+
+    function _updateRewardDelegators(address _updatedRewardDelegators) internal {
+        rewardDelegators = IRewardDelegators(_updatedRewardDelegators);
+        emit RewardDelegatorsUpdated(_updatedRewardDelegators);
+    }
+
+    //-------------------------------- Admin calls end --------------------------------//
+
+    struct OperatorManagerInfo {
+        address operatorManager; // ClusterRegistry, Executors
+        address operatorRewards; // ClusterRewards, Executors
+        address operatorSelector; // Executors
+        address rewardToken;    // POND for cluster, USDC for executors
+        bool isTwoStepDeregister;
+    }
+
+    // operatorManagerId => OperatorManagerInfo
+    mapping(bytes32 => OperatorManagerInfo) public operatorManagers;
+    // operator => operatorManagerId
+    mapping(address => bytes32) public operatorToManagerId;
+
+    // operator manager IDs -
+    // Relay service - keccak256("RELAY")
+    // Serverless executor service - keccak256("SERVERLESS_EXECUTOR")
+    // Serverless gateway service - keccak256("SERVERLESS_GATEWAY")
+
+    IRewardDelegators public rewardDelegators;
+
+    IClusterRegistry public clusterRegistry;
+
+    event RewardDelegatorsUpdated(address indexed rewardDelegators);
+    event ServiceAdded(bytes32 indexed operatorManagerId, address operatorManager, bool isTwoStepDeregister);
+    event OperatorRegistered(address indexed operator, bytes32 indexed operatorManagerId);
+    event DeregisterRequested(address indexed operator, bytes32 indexed operatorManagerId);
+    event OperatorDeregistered(address indexed operator, bytes32 indexed operatorManagerId);
+
+    error OperatorRegistry_ServiceAlreadyExists();
+    error OperatorRegistry_ServiceNotFound();
+    error OperatorRegistry_OperatorAlreadyRegistered();
+    error OperatorRegistry_OperatorNotRegistered();
+    error OperatorRegistry_TwoStepDeregisterDisabled();
+    error OperatorRegistry_DeregisterRequestFailed();
+    error OperatorRegistry_DeregistrationFailed();
+
+    function addService(
+        bytes32 _operatorManagerId,
+        address _operatorManager,
+        address _operatorRewards,
+        address _operatorSelector,
+        address _rewardToken,
+        bool _isTwoStepDeregister
+    ) external onlyAdmin {
+        if(operatorManagers[_operatorManagerId].operatorManager != address(0))
+            revert OperatorRegistry_ServiceAlreadyExists();
+
+        operatorManagers[_operatorManagerId] = OperatorManagerInfo({
+            operatorManager: _operatorManager,
+            operatorRewards: _operatorRewards,
+            operatorSelector: _operatorSelector,
+            rewardToken: _rewardToken,
+            isTwoStepDeregister: _isTwoStepDeregister
+        });
+
+        emit ServiceAdded(_operatorManagerId, _operatorManager, _isTwoStepDeregister);
+    }
+
+    // TODO: Instead of passing the _operator, we can use the msg.sender
+    function register(address _operator, bytes32 _operatorManagerId, bytes calldata _data) external {
+        if(operatorManagers[_operatorManagerId].operatorManager == address(0))
+            revert OperatorRegistry_ServiceNotFound();
+        if(operatorToManagerId[_operator] != 0 || clusterRegistry.isClusterValid(_operator))
+            revert OperatorRegistry_OperatorAlreadyRegistered();
+
+        // call to the operator manager to register the operator
+        address operatorManager = operatorManagers[_operatorManagerId].operatorManager;
+        IOperatorManager(operatorManager).registerOperator(_operator, _data);
+
+        operatorToManagerId[_operator] = _operatorManagerId;
+
+        emit OperatorRegistered(_operator, _operatorManagerId);
+    }
+
+    function requestDeregister(bytes calldata _data) external {
+        address operator = _msgSender();
+        bytes32 id = operatorToManagerId[operator];
+        if(id == bytes32(0))
+            revert OperatorRegistry_OperatorNotRegistered();
+
+        if(!operatorManagers[id].isTwoStepDeregister)
+            revert OperatorRegistry_TwoStepDeregisterDisabled();
+
+        // Low-level call to the operator manager to request deregistration
+        // if case for Relay service, else case for serverless service
+        bool success;
+        if(_data.length == 0) {
+            (success, ) = operatorManagers[id].operatorManager.call(
+                abi.encodeWithSignature("requestDeregister(address)", operator)
+            );
+        } else {
+            (success, ) = operatorManagers[id].operatorManager.call(
+                abi.encodeWithSignature("requestDeregister(address,bytes)", operator, _data)
+            );
+        }
+
+        if(!success)
+            revert OperatorRegistry_DeregisterRequestFailed();
+        
+        emit DeregisterRequested(operator, id);
+    }
+
+    function deregister(bytes calldata _data) external {
+        address operator = _msgSender();
+        bytes32 id = operatorToManagerId[operator];
+        if(id == bytes32(0))
+            revert OperatorRegistry_OperatorNotRegistered();
+
+        if(!operatorManagers[id].isTwoStepDeregister)
+            revert OperatorRegistry_TwoStepDeregisterDisabled();
+
+        // Low-level call to the operator manager to request deregistration
+        // if case for Relay service, else case for serverless service
+        bool success;
+        if(_data.length == 0) {
+            (success, ) = operatorManagers[id].operatorManager.call(
+                abi.encodeWithSignature("requestDeregister(address)", operator)
+            );
+        } else {
+            (success, ) = operatorManagers[id].operatorManager.call(
+                abi.encodeWithSignature("requestDeregister(address,bytes)", operator, _data)
+            );
+        }
+
+        if(!success)
+            revert OperatorRegistry_DeregistrationFailed();
+
+        delete operatorToManagerId[operator];
+        emit OperatorDeregistered(operator, id);
+    }
+
+    function getOperatorManager(bytes32 _operatorManagerId) external view returns (address) {
+        return operatorManagers[_operatorManagerId].operatorManager;
+    }
+
+    function getOperatorRewards(bytes32 _operatorManagerId) external view returns (address) {
+        return operatorManagers[_operatorManagerId].operatorRewards;
+    }
+
+    function getOperatorSelector(bytes32 _operatorManagerId) external view returns (address) {
+        return operatorManagers[_operatorManagerId].operatorSelector;
+    }
+
+    function getRewardToken(bytes32 _operatorManagerId) external view returns (address) {
+        return operatorManagers[_operatorManagerId].rewardToken;
+    }
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IClusterRegistry.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IClusterRegistry.sol
@@ -6,11 +6,9 @@ interface IClusterRegistry {
     function locks(bytes32 _lockId) external returns(uint256, uint256);
     function lockWaitTime(bytes32 _selectorId) external returns(uint256);
     function updateLockWaitTime(bytes32 _selector, uint256 _updatedWaitTime) external;
-    function register(
-        bytes32 _networkId,
-        uint256 _commission,
-        address _rewardAddress,
-        address _clientKey
+    function registerOperator(
+        address _operator,
+        bytes memory _data
     ) external;
     function requestCommissionUpdate(uint256 _commission) external;
     function updateCommission() external;
@@ -18,8 +16,8 @@ interface IClusterRegistry {
     function switchNetwork() external;
     function updateRewardAddress(address _rewardAddress) external;
     function updateClientKey(address _clientKey) external;
-    function requestUnregister() external;
-    function unregister() external;
+    function requestUnregister(address _cluster) external;
+    function unregister(address _cluster) external;
     function isClusterValid(address _cluster) external returns(bool);
     function getCommission(address _cluster) external returns(uint256);
     function getNetwork(address _cluster) external returns(bytes32);

--- a/contracts/staking-contracts/contracts/staking/interfaces/IInflationRewardsEmitter.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IInflationRewardsEmitter.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IInflationRewardsEmitter {
+    function getCurrentEpoch() external returns (uint256);
+
+    function emitInflationaryReward() external returns (uint256);
+
+    function rewardToken() external view returns (IERC20);
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IInflationRewardsManager.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IInflationRewardsManager.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IInflationRewardsManager {
+    function notifyOutputSubmission(address _operator) external;
+
+    function updateInflationRewards(
+        address _operator,
+        address _delegator,
+        bytes32[] memory _tokens,
+        uint256[] memory _amounts,
+        bool _isDelegation
+    ) external;
+
+    // function delegate(
+    //     address _operator,
+    //     address _delegator,
+    //     bytes32[] memory _tokens,
+    //     uint256[] memory _amounts
+    // ) external;
+
+    // function undelegate(
+    //     address _operator,
+    //     address _delegator,
+    //     bytes32[] memory _tokens,
+    //     uint256[] memory _amounts
+    // ) external;
+
+    // function withdrawRewards(address _operator,address _delegator) external;
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IOperatorManager.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IOperatorManager.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IOperatorManager {
+    function registerOperator(
+        address _operator,
+        bytes calldata _data
+    ) external;
+    function getRewardInfo(address _operator) external returns(uint256, address);
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IOperatorRegistry.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IOperatorRegistry.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IOperatorRegistry {
+    function addService(
+        bytes32 _operatorManagerId,
+        address _operatorManager,
+        address _operatorRewards,
+        address _operatorSelector,
+        address _rewardToken,
+        bool _isTwoStepDeregister
+    ) external;
+
+    function register(address _operator, bytes32 _operatorManagerId, bytes memory _data) external;
+
+    function requestDeregister(bytes memory _data) external;
+
+    function deregister(bytes memory _data) external;
+
+    function operatorToManagerId(address _operator) external view returns (bytes32);
+
+    function getOperatorManager(bytes32 _operatorManagerId) external view returns (address);
+
+    function getOperatorRewards(bytes32 _operatorManagerId) external view returns (address);
+
+    function getOperatorSelector(bytes32 _operatorManagerId) external view returns (address);
+    
+    function getRewardToken(bytes32 _operatorManagerId) external view returns (address);
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IOperatorRewards.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IOperatorRewards.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IOperatorRewards {
+    function claimReward(address operator) external returns(uint256);
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IOperatorSelector.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IOperatorSelector.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+interface IOperatorSelector {
+    function updateOperatorSelector(address operator, uint256 totalDelegation) external;
+
+    function removeOperatorSelector(address operator) external;
+}

--- a/contracts/staking-contracts/contracts/staking/interfaces/IRewardDelegators.sol
+++ b/contracts/staking-contracts/contracts/staking/interfaces/IRewardDelegators.sol
@@ -7,7 +7,7 @@ interface IRewardDelegators {
     function addRewardFactor(bytes32 _tokenId, uint256 _rewardFactor) external;
     function removeRewardFactor(bytes32 _tokenId) external;
     function updateRewardFactor(bytes32 _tokenId, uint256 _updatedRewardFactor) external;
-    function _updateRewards(address _cluster) external;
+    function _updateRewards(address _cluster, bytes32 _operatorManagerId) external;
     function delegate(
         address _delegator,
         address _cluster,
@@ -32,4 +32,23 @@ interface IRewardDelegators {
     function getAccRewardPerShare(address _cluster, bytes32 _tokenId) external view returns(uint256);
     function updateClusterDelegation(address _cluster, bytes32 _networkId) external;
     function removeClusterDelegation(address _cluster, bytes32 _networkId) external;
+    function lockTokens(
+        address _operator,
+        bytes32 _lockId,
+        uint256 _amount
+        // bytes32[] memory _tokens,
+        // uint256[] memory _amounts
+    ) external;
+    function unlockTokens(
+        address _operator,
+        bytes32 _lockId
+    ) external;
+    function slash(
+        address _operator,
+        bytes32 _lockId
+    ) external;
+    function getTotalDelegation(
+        address cluster
+    ) external view returns(uint256 _totalWeight, uint256 totalDelegations);
+    function getTokenList() external view returns (bytes32[] memory);
 }


### PR DESCRIPTION
It updates the existing staking pool used by Marlin’s Relay Network, allowing for smooth transitions without requiring any transfer of tokens that have already been staked, and integration of Oyster serverless.

PoC Doc- https://docs.google.com/document/d/1OLQA_vlylkVLdPW10JiEBRlRmqB8u3UHR-Y-9uYPSsg/edit?usp=sharing