### PR TITLE
Add health monitoring with 3-level status for operator dashboard

### DIFF
--- a/operator/control-plane/Cargo.toml
+++ b/operator/control-plane/Cargo.toml
@@ -27,7 +27,7 @@ base64 = "0.22.1"
 clap = { version = "4.5.23", features = ["derive"] }
 hex = "0.4.3"
 rand_core = { version = "0.6.4", features = ["getrandom"] }
-reqwest = { version = "0.12.12", features = ["rustls-tls"], default-features = false }
+reqwest = { version = "0.12.12", features = ["rustls-tls", "json"], default-features = false }
 serde = "1.0.217"
 serde_json = "1.0.134"
 shell-escape = "0.1.5"

--- a/operator/control-plane/src/health.rs
+++ b/operator/control-plane/src/health.rs
@@ -1,0 +1,393 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, SystemTime};
+
+use anyhow::{Context, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tokio::time::interval;
+
+const STARTUP_GRACE_SECS: u64 = 300;
+const UNHEALTHY_CONSECUTIVE_ERRORS: u64 = 5;
+const DEGRADED_CONSECUTIVE_ERRORS: u64 = 3;
+const UNHEALTHY_ERROR_RATE: f64 = 0.30;
+const DEGRADED_ERROR_RATE: f64 = 0.15;
+const UNHEALTHY_STALE_SECS: u64 = 180;
+const DEGRADED_STALE_SECS: u64 = 60;
+const INDEXER_HEALTH_CALL_TIMEOUT_SECS: u64 = 2;
+const INDEXER_HEALTH_POLL_INTERVAL_SECS: u64 = 10;
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+#[derive(Clone, Deserialize)]
+pub struct HealthReport {
+    pub status: HealthStatus,
+    pub reason: Option<String>,
+}
+
+#[derive(Clone)]
+struct CachedIndexerHealthState {
+    status: HealthStatus,
+    reason: Option<String>,
+    last_updated: SystemTime,
+}
+
+#[derive(Clone)]
+pub struct IndexerHealthTracker {
+    state: Arc<Mutex<CachedIndexerHealthState>>,
+}
+
+impl Default for IndexerHealthTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IndexerHealthTracker {
+    pub fn new() -> Self {
+        let state = CachedIndexerHealthState {
+            status: HealthStatus::Unhealthy,
+            reason: None,
+            last_updated: SystemTime::now(),
+        };
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub fn spawn_polling_task(&self, indexer_url: String) -> Result<()> {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(INDEXER_HEALTH_CALL_TIMEOUT_SECS))
+            .build()
+            .context("Failed to build HTTP client")?;
+        let state = self.clone();
+
+        tokio::spawn(async move {
+            poll_indexer_health(indexer_url.as_str(), client, state.clone()).await
+        });
+
+        Ok(())
+    }
+
+    pub fn get_report(&self) -> HealthReport {
+        let state = self.state.lock().unwrap().clone();
+        let now = SystemTime::now();
+
+        if now
+            .duration_since(state.last_updated)
+            .unwrap_or(Duration::MAX)
+            > Duration::from_secs(INDEXER_HEALTH_POLL_INTERVAL_SECS * 3)
+        {
+            return HealthReport {
+                status: HealthStatus::Unhealthy,
+                reason: Some("indexer_health_stale".into()),
+            };
+        }
+
+        HealthReport {
+            status: state.status,
+            reason: state.reason,
+        }
+    }
+
+    #[cfg(test)]
+    pub fn set_test_status(&self, status: HealthStatus, reason: Option<String>) {
+        let mut state = self.state.lock().unwrap();
+        state.status = status;
+        state.reason = reason;
+        state.last_updated = SystemTime::now();
+    }
+}
+
+#[derive(Clone)]
+struct HealthState {
+    start_time: SystemTime,
+    last_success: SystemTime,
+    recent_checks: VecDeque<bool>,
+    last_error: Option<String>,
+}
+
+#[derive(Clone)]
+pub struct HealthTracker {
+    state: Arc<Mutex<HealthState>>,
+}
+
+impl Default for HealthTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HealthTracker {
+    pub fn new() -> Self {
+        let now = SystemTime::now();
+        let state = HealthState {
+            start_time: now,
+            last_success: now,
+            recent_checks: VecDeque::new(),
+            last_error: None,
+        };
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub fn record_success(&self) {
+        let mut state = self.state.lock().unwrap();
+        state.last_success = SystemTime::now();
+        state.last_error = None;
+        state.recent_checks.push_back(true);
+        Self::trim(&mut state.recent_checks);
+    }
+
+    pub fn record_error(&self, msg: impl Into<String>) {
+        let mut state = self.state.lock().unwrap();
+        state.last_error = Some(msg.into());
+        state.recent_checks.push_back(false);
+        Self::trim(&mut state.recent_checks);
+    }
+
+    pub fn get_report(&self) -> HealthReport {
+        let state = self.state.lock().unwrap().clone();
+        let now = SystemTime::now();
+
+        let uptime = now.duration_since(state.start_time).unwrap_or_default();
+        let time_since_success = now
+            .duration_since(state.last_success)
+            .unwrap_or(Duration::MAX);
+
+        let consecutive_errors = Self::count_consecutive(&state.recent_checks, false);
+        let error_rate = Self::error_rate(&state.recent_checks);
+
+        let unhealthy = consecutive_errors >= UNHEALTHY_CONSECUTIVE_ERRORS
+            || error_rate > UNHEALTHY_ERROR_RATE
+            || time_since_success > Duration::from_secs(UNHEALTHY_STALE_SECS);
+
+        if unhealthy && uptime < Duration::from_secs(STARTUP_GRACE_SECS) {
+            return HealthReport {
+                status: HealthStatus::Degraded,
+                reason: Some("startup_instability".into()),
+            };
+        }
+
+        if unhealthy {
+            return HealthReport {
+                status: HealthStatus::Unhealthy,
+                reason: Some("sustained_errors_or_stall".into()),
+            };
+        }
+
+        if consecutive_errors >= DEGRADED_CONSECUTIVE_ERRORS
+            || error_rate > DEGRADED_ERROR_RATE
+            || time_since_success > Duration::from_secs(DEGRADED_STALE_SECS)
+        {
+            return HealthReport {
+                status: HealthStatus::Degraded,
+                reason: Some("intermittent_errors_or_staleness".into()),
+            };
+        }
+
+        HealthReport {
+            status: HealthStatus::Healthy,
+            reason: None,
+        }
+    }
+
+    fn trim(buf: &mut VecDeque<bool>) {
+        const MAX: usize = 100;
+        while buf.len() > MAX {
+            buf.pop_front();
+        }
+    }
+
+    fn count_consecutive(buf: &VecDeque<bool>, value: bool) -> u64 {
+        buf.iter().rev().take_while(|&&v| v == value).count() as u64
+    }
+
+    fn error_rate(buf: &VecDeque<bool>) -> f64 {
+        if buf.is_empty() {
+            return 0.0;
+        }
+        let errors = buf.iter().filter(|&&v| !v).count();
+        errors as f64 / buf.len() as f64
+    }
+}
+
+async fn poll_indexer_health(indexer_url: &str, client: Client, health: IndexerHealthTracker) {
+    let mut interval = interval(Duration::from_secs(INDEXER_HEALTH_POLL_INTERVAL_SECS));
+
+    loop {
+        interval.tick().await;
+
+        let result = client
+            .get(format!("{}/health", indexer_url))
+            .send()
+            .await
+            .and_then(|r| r.error_for_status());
+
+        match result {
+            Ok(resp) => {
+                let report_json = resp.json::<HealthReport>().await;
+                let mut guard = health.state.lock().unwrap();
+
+                match report_json {
+                    Ok(report) => {
+                        *guard = CachedIndexerHealthState {
+                            status: report.status,
+                            reason: report.reason,
+                            last_updated: SystemTime::now(),
+                        };
+                    }
+                    Err(_) => {
+                        *guard = CachedIndexerHealthState {
+                            status: HealthStatus::Unhealthy,
+                            reason: Some("indexer_health_parse_failed".into()),
+                            last_updated: SystemTime::now(),
+                        };
+                    }
+                }
+            }
+            Err(_) => {
+                let mut guard = health.state.lock().unwrap();
+                *guard = CachedIndexerHealthState {
+                    status: HealthStatus::Unhealthy,
+                    reason: Some("indexer_unreachable".into()),
+                    last_updated: SystemTime::now(),
+                };
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_health_tracker_starts_healthy() {
+        let tracker = HealthTracker::new();
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Healthy);
+        assert!(report.reason.is_none());
+    }
+
+    #[test]
+    fn test_health_tracker_uptime_consecutive_errors() {
+        let tracker = HealthTracker::new();
+
+        for _ in 0..5 {
+            tracker.record_error("test error");
+        }
+
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Degraded);
+        assert!(report.reason.is_some());
+        assert!(report.reason.unwrap().contains("startup_instability"));
+    }
+
+    #[test]
+    fn test_health_tracker_unhealthy_consecutive_errors() {
+        let tracker = HealthTracker::new();
+
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.start_time = SystemTime::now() - Duration::from_secs(400);
+        }
+
+        for _ in 0..5 {
+            tracker.record_error("test error");
+        }
+
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Unhealthy);
+        assert!(report.reason.is_some());
+        assert!(report.reason.unwrap().contains("sustained_errors"));
+    }
+
+    #[test]
+    fn test_health_tracker_error_rate() {
+        let tracker = HealthTracker::new();
+
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.start_time = SystemTime::now() - Duration::from_secs(400);
+        }
+
+        for _ in 0..6 {
+            tracker.record_success();
+        }
+        for _ in 0..4 {
+            tracker.record_error("test error");
+        }
+
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Unhealthy);
+        assert!(report.reason.is_some());
+        assert!(report.reason.unwrap().contains("sustained_errors"));
+    }
+
+    #[test]
+    fn test_health_tracker_staleness() {
+        let tracker = HealthTracker::new();
+
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.start_time = SystemTime::now() - Duration::from_secs(400);
+            state.last_success = SystemTime::now() - Duration::from_secs(200); // > 180s
+        }
+
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Unhealthy);
+        assert!(report.reason.is_some());
+        assert!(report.reason.unwrap().contains("sustained_errors"));
+    }
+
+    #[test]
+    fn test_health_tracker_recovery() {
+        let tracker = HealthTracker::new();
+
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.start_time = SystemTime::now() - Duration::from_secs(400);
+        }
+
+        for _ in 0..5 {
+            tracker.record_error("test error");
+        }
+        assert_eq!(tracker.get_report().status, HealthStatus::Unhealthy);
+
+        for _ in 0..30 {
+            tracker.record_success();
+        }
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Healthy);
+    }
+
+    #[test]
+    fn test_indexer_health_tracker_starts_unhealthy() {
+        let tracker = IndexerHealthTracker::new();
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Unhealthy);
+        assert!(report.reason.is_none());
+    }
+
+    #[test]
+    fn test_indexer_health_tracker_stale() {
+        let tracker = IndexerHealthTracker::new();
+
+        {
+            let mut state = tracker.state.lock().unwrap();
+            state.last_updated = SystemTime::now() - Duration::from_secs(35); // > 30s (3*10)
+        }
+
+        let report = tracker.get_report();
+        assert_eq!(report.status, HealthStatus::Unhealthy);
+        assert!(report.reason.is_some());
+        assert!(report.reason.unwrap().contains("stale"));
+    }
+}

--- a/operator/control-plane/src/lib.rs
+++ b/operator/control-plane/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod aws;
+pub mod health;
 pub mod market;
 pub mod server;
 #[cfg(test)]

--- a/operator/market-indexer/arb/Cargo.lock
+++ b/operator/market-indexer/arb/Cargo.lock
@@ -1120,6 +1120,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2156,6 +2208,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2168,6 +2226,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -2380,6 +2439,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "axum",
  "serde",
  "serde_json",
  "sqlx",
@@ -2641,6 +2701,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2655,6 +2721,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -3662,6 +3734,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4393,6 +4476,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]

--- a/operator/market-indexer/arb/src/main.rs
+++ b/operator/market-indexer/arb/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use clap::{Parser, command};
 use dotenvy::dotenv;
+use indexer_framework::health::{HealthTracker, start_health_server};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
@@ -34,6 +35,10 @@ struct Args {
     /// Size of block range for fetching logs
     #[arg(long, default_value = "500")]
     range_size: u64,
+
+    /// Health check port
+    #[arg(long, default_value = "8080")]
+    health_port: u16,
 }
 
 #[tokio::main]
@@ -54,6 +59,20 @@ async fn main() -> Result<()> {
 
     let args = Args::parse();
     let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL must be set")?;
+
+    let health = HealthTracker::new();
+    let health_clone = health.clone();
+    tokio::spawn(async move {
+        loop {
+            if let Err(e) = start_health_server(health_clone.clone(), args.health_port).await {
+                error!(error = ?e, "Health server crashed, restarting in 5s");
+                sleep(Duration::from_secs(5)).await;
+            } else {
+                warn!("Health server exited, restarting in 5s");
+                sleep(Duration::from_secs(5)).await;
+            }
+        }
+    });
 
     let rpc_client = ArbProvider::new(
         args.rpc
@@ -80,11 +99,14 @@ async fn main() -> Result<()> {
             args.provider.clone(),
             args.start_block,
             args.range_size,
+            health.clone(),
         )
         .await;
 
         if let Err(e) = res {
+            let error_message = format!("Indexer run error: {:?}", e);
             error!(error = ?e, "Indexer error, retrying after delay");
+            health.record_error(error_message);
             sleep(Duration::from_secs(30)).await;
         } else {
             warn!("Indexer returned unexpectedly, restarting");

--- a/operator/market-indexer/arb/src/main.rs
+++ b/operator/market-indexer/arb/src/main.rs
@@ -5,13 +5,23 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use clap::{Parser, command};
 use dotenvy::dotenv;
-use indexer_framework::health::{HealthTracker, start_health_server};
+use indexer_framework::health::{HealthConfig, HealthTracker, start_health_server};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 use tracing_subscriber::filter::LevelFilter;
 
 use arb::ArbProvider;
+
+const STARTUP_GRACE_SECS: u64 = 300;
+const UNHEALTHY_CONSECUTIVE_ERRORS: u64 = 5;
+const DEGRADED_CONSECUTIVE_ERRORS: u64 = 3;
+const UNHEALTHY_ERROR_RATE: f64 = 0.30;
+const DEGRADED_ERROR_RATE: f64 = 0.15;
+const UNHEALTHY_STALE_SECS: u64 = 180;
+const DEGRADED_STALE_SECS: u64 = 60;
+const UNHEALTHY_LAG: i64 = 500;
+const DEGRADED_LAG: i64 = 200;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -60,11 +70,23 @@ async fn main() -> Result<()> {
     let args = Args::parse();
     let database_url = std::env::var("DATABASE_URL").context("DATABASE_URL must be set")?;
 
-    let health = HealthTracker::new();
+    let health = HealthTracker::new(HealthConfig {
+        startup_grace: Duration::from_secs(STARTUP_GRACE_SECS),
+        unhealthy_consecutive_errors: UNHEALTHY_CONSECUTIVE_ERRORS,
+        degraded_consecutive_errors: DEGRADED_CONSECUTIVE_ERRORS,
+        unhealthy_error_rate: UNHEALTHY_ERROR_RATE,
+        degraded_error_rate: DEGRADED_ERROR_RATE,
+        unhealthy_stale: Duration::from_secs(UNHEALTHY_STALE_SECS),
+        degraded_stale: Duration::from_secs(DEGRADED_STALE_SECS),
+        unhealthy_lag: UNHEALTHY_LAG,
+        degraded_lag: DEGRADED_LAG,
+    });
     let health_clone = health.clone();
+    let health_port = args.health_port;
+
     tokio::spawn(async move {
         loop {
-            if let Err(e) = start_health_server(health_clone.clone(), args.health_port).await {
+            if let Err(e) = start_health_server(health_clone.clone(), health_port).await {
                 error!(error = ?e, "Health server crashed, restarting in 5s");
                 sleep(Duration::from_secs(5)).await;
             } else {
@@ -93,6 +115,8 @@ async fn main() -> Result<()> {
     );
 
     loop {
+        info!("Starting indexer run");
+
         let res = indexer_framework::run(
             database_url.clone(),
             rpc_client.clone(),
@@ -104,12 +128,11 @@ async fn main() -> Result<()> {
         .await;
 
         if let Err(e) = res {
-            let error_message = format!("Indexer run error: {:?}", e);
             error!(error = ?e, "Indexer error, retrying after delay");
-            health.record_error(error_message);
             sleep(Duration::from_secs(30)).await;
         } else {
-            warn!("Indexer returned unexpectedly, restarting");
+            warn!("Indexer returned unexpectedly (no error), restarting in 5s");
+            health.record_error("indexer_run_failed_unexpectedly");
             sleep(Duration::from_secs(5)).await;
         }
     }

--- a/operator/market-indexer/framework/Cargo.lock
+++ b/operator/market-indexer/framework/Cargo.lock
@@ -271,6 +271,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "auto_impl"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -286,6 +292,58 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "axum"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b098575ebe77cb6d14fc7f32749631a6e44edbef6b796f89b020e99ba20d425"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59446ce19cd142f8833f856eb31f3eb097812d1479ab224f54d72428ca21ea22"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "backtrace"
@@ -993,6 +1051,88 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1125,6 +1265,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "axum",
  "serde",
  "serde_json",
  "sqlx",
@@ -1283,6 +1424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1297,6 +1444,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "miniz_oxide"
@@ -2000,6 +2153,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2364,6 +2528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
 name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2699,34 @@ checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"

--- a/operator/market-indexer/framework/Cargo.toml
+++ b/operator/market-indexer/framework/Cargo.toml
@@ -7,6 +7,7 @@ license = "AGPL-3.0-or-later"
 [dependencies]
 alloy-primitives = { version = "1.3.1", features = ["serde"] }
 anyhow = "1.0.95"
+axum = { version = "0.8.7", features = ["json"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.134"
 sqlx = { version = "0.8.6", features = ["runtime-tokio-rustls", "postgres", "json"] }

--- a/operator/market-indexer/framework/src/health.rs
+++ b/operator/market-indexer/framework/src/health.rs
@@ -1,0 +1,94 @@
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::Result;
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::Json;
+use axum::routing::get;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::net::TcpListener;
+use tracing::info;
+
+#[derive(Clone, Default)]
+pub struct HealthTracker {
+    inner: Arc<Mutex<HealthState>>,
+}
+
+#[derive(Default, Serialize, Clone)]
+pub struct HealthState {
+    pub healthy: bool,
+    pub last_error: Option<String>,
+    pub last_error_time: Option<SystemTime>,
+    pub last_successful_block: Option<i64>,
+    pub consecutive_errors: u64,
+}
+
+impl HealthTracker {
+    pub fn new() -> Self {
+        let state = HealthState {
+            healthy: true,
+            ..Default::default()
+        };
+        Self {
+            inner: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    pub fn record_success(&self, last_block: i64) {
+        let mut state = self.inner.lock().unwrap();
+        state.healthy = true;
+        state.last_error = None;
+        state.last_error_time = None;
+        state.last_successful_block = Some(last_block);
+        state.consecutive_errors = 0;
+    }
+
+    pub fn record_error(&self, msg: impl Into<String>) {
+        let mut state = self.inner.lock().unwrap();
+        state.healthy = false;
+        state.last_error = Some(msg.into());
+        state.last_error_time = Some(SystemTime::now());
+        state.consecutive_errors = state.consecutive_errors.saturating_add(1);
+    }
+
+    pub fn get_status(&self) -> HealthState {
+        self.inner.lock().unwrap().clone()
+    }
+}
+
+/// Start health check HTTP server
+pub async fn start_health_server(health: HealthTracker, port: u16) -> Result<()> {
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .with_state(health);
+
+    let listener = TcpListener::bind(format!("0.0.0.0:{}", port)).await?;
+    info!("Health check server listening on port {}", port);
+
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
+async fn health_handler(State(health): State<HealthTracker>) -> (StatusCode, Json<Value>) {
+    let status = health.get_status();
+    let status_code = if status.healthy {
+        StatusCode::OK
+    } else {
+        StatusCode::SERVICE_UNAVAILABLE
+    };
+
+    let response = json!({
+        "healthy": status.healthy,
+        "last_error": status.last_error,
+        "last_error_time": status.last_error_time
+            .and_then(|t| t.duration_since(UNIX_EPOCH).ok())
+            .map(|d| d.as_secs()),
+        "last_successful_block": status.last_successful_block,
+        "consecutive_errors": status.consecutive_errors,
+    });
+
+    (status_code, Json(response))
+}

--- a/operator/market-indexer/sui/Cargo.lock
+++ b/operator/market-indexer/sui/Cargo.lock
@@ -350,6 +350,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "axum"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -363,9 +415,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d809780667f4410e7c41b07f52439b94d2bdf8528eeedc287fa38d3b7f95d82"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bcs"
@@ -490,9 +542,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.51"
+version = "1.2.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0aeaff4ff1a90589618835a598e545176939b97874f7abc7851caa0618f203"
+checksum = "cd4932aefd12402b36c60956a4fe0035421f544799057659ff86f923657aada3"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -558,9 +610,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
@@ -935,9 +987,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "645cbb3a84e60b7531617d5ae4e57f7e27308f6445f5abf653209ea76dec8dff"
+checksum = "f449e6c6c08c865631d4890cfacf252b3d396c9bcc83adb6623cdb02a8336c41"
 
 [[package]]
 name = "fixed-hash"
@@ -1108,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1273,6 +1325,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1286,6 +1344,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "pin-utils",
@@ -1476,6 +1535,7 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "anyhow",
+ "axum",
  "serde",
  "serde_json",
  "sqlx",
@@ -1614,9 +1674,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.179"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a2d376baa530d1238d133232d15e239abad80d05838b4b59354e5268af431f"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "libm"
@@ -1688,6 +1748,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "md-5"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1702,6 +1768,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -2038,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -2048,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
@@ -2061,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.14.1"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9b4db3d6da204ed77bb26ba83b6122a73aeb2e87e25fbf7ad2e84c4ccbf8f72"
+checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost",
 ]
@@ -2168,7 +2240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
  "serde",
 ]
 
@@ -2189,7 +2261,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2198,14 +2270,14 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
  "serde",
@@ -2217,14 +2289,14 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core 0.9.3",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "rapidhash"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2988730ee014541157f48ce4dcc603940e00915edc3c7f9a8d78092256bb2493"
+checksum = "5d8b5b858a440a0bc02625b62dd95131b9201aa9f69f411195dd4a7cfb1de3d7"
 dependencies = [
  "rustversion",
 ]
@@ -2320,7 +2392,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.16",
+ "getrandom 0.2.17",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -2588,6 +2660,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2965,7 +3048,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sui-rpc"
 version = "0.2.1"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk/#5a2f2d6bd5788d2c0f5644edbdcde23102f88663"
+source = "git+https://github.com/mystenlabs/sui-rust-sdk/#57b6cb6a17198d291637b64ef7cb8807796a3af9"
 dependencies = [
  "base64",
  "bcs",
@@ -2986,7 +3069,7 @@ dependencies = [
 [[package]]
 name = "sui-sdk-types"
 version = "0.2.1"
-source = "git+https://github.com/mystenlabs/sui-rust-sdk/#5a2f2d6bd5788d2c0f5644edbdcde23102f88663"
+source = "git+https://github.com/mystenlabs/sui-rust-sdk/#57b6cb6a17198d291637b64ef7cb8807796a3af9"
 dependencies = [
  "base64ct",
  "bcs",
@@ -3116,22 +3199,22 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.44"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
+checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
 dependencies = [
  "deranged",
  "num-conv",
  "powerfmt",
- "serde",
+ "serde_core",
  "time-core",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
 
 [[package]]
 name = "tiny-keccak"
@@ -3312,9 +3395,9 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
@@ -4066,9 +4149,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc5a66a20078bf1251bde995aa2fdcc4b800c70b5d92dd2c62abc5c60f679f8"
+checksum = "bd8f3f50b848df28f887acb68e41201b5aea6bc8a8dacc00fb40635ff9a72fea"
 
 [[package]]
 name = "zstd"

--- a/operator/market-indexer/sui/src/main.rs
+++ b/operator/market-indexer/sui/src/main.rs
@@ -5,6 +5,7 @@ use std::time::Duration;
 use anyhow::{Context, Result};
 use clap::{Parser, command};
 use dotenvy::dotenv;
+use indexer_framework::SaturatingConvert;
 use indexer_framework::health::{HealthConfig, HealthTracker, start_health_server};
 use tokio::time::sleep;
 use tracing::{error, info, warn};
@@ -16,12 +17,12 @@ use crate::sui::SuiProvider;
 const STARTUP_GRACE_SECS: u64 = 300;
 const UNHEALTHY_CONSECUTIVE_ERRORS: u64 = 5;
 const DEGRADED_CONSECUTIVE_ERRORS: u64 = 3;
-const UNHEALTHY_ERROR_RATE: f64 = 0.30;
-const DEGRADED_ERROR_RATE: f64 = 0.15;
+const UNHEALTHY_ERROR_RATE: f64 = 0.40;
+const DEGRADED_ERROR_RATE: f64 = 0.20;
 const UNHEALTHY_STALE_SECS: u64 = 180;
 const DEGRADED_STALE_SECS: u64 = 60;
-const UNHEALTHY_LAG: i64 = 300;
-const DEGRADED_LAG: i64 = 100;
+const UNHEALTHY_LAG_WINDOW: i64 = 3;
+const DEGRADED_LAG_WINDOW: i64 = 2;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -94,8 +95,8 @@ async fn main() -> Result<()> {
         degraded_error_rate: DEGRADED_ERROR_RATE,
         unhealthy_stale: Duration::from_secs(UNHEALTHY_STALE_SECS),
         degraded_stale: Duration::from_secs(DEGRADED_STALE_SECS),
-        unhealthy_lag: UNHEALTHY_LAG,
-        degraded_lag: DEGRADED_LAG,
+        unhealthy_lag: args.range_size.saturating_to() * UNHEALTHY_LAG_WINDOW,
+        degraded_lag: args.range_size.saturating_to() * DEGRADED_LAG_WINDOW,
     });
     let health_clone = health.clone();
     let health_port = args.health_port;


### PR DESCRIPTION
* Implements health tracking and monitoring for the operator ecosystem, providing 3-level health status (Healthy/Degraded/Unhealthy) for the UI dashboard to help users select operators safely
* Adds `HealthTracker` and `IndexerHealthTracker` in control-plane for monitoring DB operations and polling indexer health, with combined status in `/health` endpoint
* Enhances market-indexer framework `HealthTracker` with chain lag detection and block progress tracking, serving health status via `/health` endpoint
* Integrates health tracking into arb and sui indexers with configurable health servers (default port 8080)
* Includes configurable thresholds for error rates, consecutive errors, staleness, and lag windows, with startup grace periods to prevent false alarms
* Focuses solely on high-level health status for UI display, not detailed metrics or error messages
* Thresholds are configurable but not final, subject to testing and adjustment in production environments