### PR TITLE
add epoch timestamp to rate revision requests

### DIFF
--- a/contracts/indexer/oyster/evm/src/handlers/job_closed.rs
+++ b/contracts/indexer/oyster/evm/src/handlers/job_closed.rs
@@ -253,6 +253,7 @@ mod tests {
                 "0x3333333333333333333333333333333333333333333333333333333333333333".to_owned(),
                 BigDecimal::from(0),
                 creation_now.add(Duration::from_secs(600)),
+                BigDecimal::from(creation_timestamp + 600)
             ))
         );
 

--- a/contracts/indexer/oyster/evm/src/handlers/job_revise_rate_finalized.rs
+++ b/contracts/indexer/oyster/evm/src/handlers/job_revise_rate_finalized.rs
@@ -290,6 +290,7 @@ mod tests {
                 "0x3333333333333333333333333333333333333333333333333333333333333333".to_owned(),
                 BigDecimal::from(5),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -476,6 +477,7 @@ mod tests {
                 "0x4444444444444444444444444444444444444444444444444444444444444444".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -638,6 +640,7 @@ mod tests {
                 "0x4444444444444444444444444444444444444444444444444444444444444444".to_owned(),
                 BigDecimal::from(5),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 

--- a/contracts/indexer/oyster/evm/src/handlers/job_revise_rate_initiated.rs
+++ b/contracts/indexer/oyster/evm/src/handlers/job_revise_rate_initiated.rs
@@ -81,6 +81,7 @@ pub fn handle_job_revise_rate_initiated(
                     jobs::id,
                     new_rate.as_sql::<Numeric>(),
                     updates_at.as_sql::<Timestamp>(),
+                    updates_at_epoch.as_sql::<Numeric>(),
                 ))
                 .filter(jobs::is_closed.eq(false))
                 .filter(jobs::id.eq(&id)),

--- a/contracts/indexer/oyster/framework/migrations/2024-09-15-151144_create_revise_rate_requests/up.sql
+++ b/contracts/indexer/oyster/framework/migrations/2024-09-15-151144_create_revise_rate_requests/up.sql
@@ -1,5 +1,6 @@
 CREATE TABLE revise_rate_requests (
   id CHAR(66) PRIMARY KEY REFERENCES jobs (id),
   value NUMERIC NOT NULL,
-  updates_at TIMESTAMP NOT NULL
+  updates_at TIMESTAMP NOT NULL,
+  updates_at_epoch NUMERIC NOT NULL
 )

--- a/contracts/indexer/oyster/framework/src/schema.rs
+++ b/contracts/indexer/oyster/framework/src/schema.rs
@@ -52,6 +52,7 @@ diesel::table! {
         id -> Varchar,
         value -> Numeric,
         updates_at -> Timestamp,
+        updates_at_epoch -> Numeric,
     }
 }
 

--- a/contracts/indexer/oyster/sui/src/handlers/job_closed.rs
+++ b/contracts/indexer/oyster/sui/src/handlers/job_closed.rs
@@ -237,6 +237,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 creation_now.add(Duration::from_secs(600)),
+                BigDecimal::from(creation_timestamp + (600)),
             ))
         );
 

--- a/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_finalized.rs
+++ b/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_finalized.rs
@@ -267,6 +267,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(200),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -411,6 +412,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -539,6 +541,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -593,6 +596,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -672,6 +676,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 
@@ -723,6 +728,7 @@ mod tests {
                 "0x00000000000000000000000000000001".to_owned(),
                 BigDecimal::from(0),
                 original_now.add(Duration::from_secs(600)),
+                BigDecimal::from(original_timestamp + 600),
             ))
         );
 

--- a/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_initiated.rs
+++ b/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_initiated.rs
@@ -86,6 +86,7 @@ pub fn handle_job_revise_rate_initiated(
                     jobs::id,
                     new_rate.as_sql::<Numeric>(),
                     updates_at.as_sql::<Timestamp>(),
+                    updates_at_epoch.as_sql::<Numeric>(),
                 ))
                 .filter(jobs::is_closed.eq(false))
                 .filter(jobs::id.eq(&id)),

--- a/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_initiated.rs
+++ b/contracts/indexer/oyster/sui/src/handlers/job_revise_rate_initiated.rs
@@ -13,7 +13,6 @@ use indexer_framework::schema::lock_duration;
 use indexer_framework::schema::revise_rate_requests;
 use indexer_framework::LogsProvider;
 use serde::Deserialize;
-use tracing::warn;
 use tracing::{info, instrument};
 
 use crate::provider::ParsedSuiLog;

--- a/contracts/indexer/oyster/sui/src/handlers/test_utils/test_helpers.rs
+++ b/contracts/indexer/oyster/sui/src/handlers/test_utils/test_helpers.rs
@@ -126,14 +126,14 @@ pub fn encode_job_revise_rate_finalized_event(job_id: u128, new_rate: u64) -> Ve
 // ============================================================================
 
 /// BCS-encode a LockWaitTimeUpdated event
-/// Event structure: { prev_lock_time: u64, updated_lock_time: u64 }
+/// Event structure: { selector: Vec<u8>, prev_lock_time: u64, updated_lock_time: u64 }
 pub fn encode_lock_wait_time_updated_event(
     selector: Vec<u8>,
     prev_lock_time: u64,
     updated_lock_time: u64,
 ) -> Vec<u8> {
     let mut data = Vec::new();
-    data.extend_from_slice(&selector);
+    encode_bytes(&mut data, &selector);
     data.extend_from_slice(&prev_lock_time.to_le_bytes());
     data.extend_from_slice(&updated_lock_time.to_le_bytes());
     data
@@ -145,7 +145,11 @@ pub fn encode_lock_wait_time_updated_event(
 
 /// Encode a string in BCS format (ULEB128 length + UTF-8 bytes)
 fn encode_string(data: &mut Vec<u8>, s: &str) {
-    let bytes = s.as_bytes();
+    encode_bytes(data, s.as_bytes());
+}
+
+/// Encode a byte vector in BCS format (ULEB128 length + raw bytes)
+fn encode_bytes(data: &mut Vec<u8>, bytes: &[u8]) {
     encode_uleb128(data, bytes.len() as u64);
     data.extend_from_slice(bytes);
 }


### PR DESCRIPTION
In the frontend, there were a couple of places where dates and timers needed to be rendered according to local system time. For that, we want to now add an epoch timestamp for the `updates_at` column in the `revise_rate_requests` table