### PR TITLE
fix(indexer): handle zero-rate jobs in deposit/withdraw

### DIFF
--- a/contracts/indexer/oyster/evm/src/handlers/job_deposited.rs
+++ b/contracts/indexer/oyster/evm/src/handlers/job_deposited.rs
@@ -61,7 +61,11 @@ pub fn handle_job_deposited(conn: &mut PgConnection, log: Log) -> Result<()> {
 
     let rate = rate.unwrap();
 
-    let additional_duration = ((&amount * RATE_SCALING_FACTOR) / &rate).round(0);
+    let additional_duration = if &rate != &BigDecimal::from(0) {
+        ((&amount * RATE_SCALING_FACTOR) / &rate).round(0)
+    } else {
+        BigDecimal::from(0)
+    };
 
     info!(
         id,

--- a/contracts/indexer/oyster/evm/src/handlers/job_withdrew.rs
+++ b/contracts/indexer/oyster/evm/src/handlers/job_withdrew.rs
@@ -59,7 +59,11 @@ pub fn handle_job_withdrew(conn: &mut PgConnection, log: Log) -> Result<()> {
     }
 
     let rate = rate.unwrap();
-    let duration_removed = ((&amount * RATE_SCALING_FACTOR) / &rate).round(0);
+    let duration_removed = if &rate != &BigDecimal::from(0) {
+        ((&amount * RATE_SCALING_FACTOR) / &rate).round(0)
+    } else {
+        BigDecimal::from(0)
+    };
 
     info!(?rate, ?duration_removed, "duration removed");
 


### PR DESCRIPTION
  Mirror the rate==0 guard already present in job_opened and
  job_revise_rate_finalized to avoid a bigdecimal "Division by zero" panic
  when processing deposits/withdrawals on zero-rate jobs.